### PR TITLE
Add query logging of all presto queries

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/execution/SqlQueryManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/SqlQueryManager.java
@@ -306,6 +306,10 @@ public class SqlQueryManager
                 stats.queryFinished(info);
                 queryMonitor.completionEvent(info);
                 expirationQueue.add(queryExecution);
+                log.info(String.format("Query complete\t%s\t%s\t%s\t%s\t%s\t%s\t%s",
+                        info.getQueryId(), newValue, info.getErrorType(), info.getErrorCode(),
+                        session.getUser(), info.getQueryStats().getElapsedTime(),
+                        info.getQuery().replace(System.getProperty("line.separator"), " ")));
             }
         });
 


### PR DESCRIPTION
Adds logging of all queries executed, their end state, user and duration. We'd like to be able to post-process these logs and track the number of successful and failed queries over time. This could certainly be done more fancy with pluggable logging modules or a new query.log file, but this seems like a reasonable first pass.

Format (tab-delimited):
```QUERY_ID STATE ERROR_TYPE ERROR_CODE USER ELAPSED_TIME QUERY```

Executing this in the shell:
```
presto> set session
     -> invalid.property.key='foo';
...
presto> show catalogs;
...
```
Produces this in ```server.log```:
```
2016-02-24T14:44:10.398-0800	INFO	query-execution-1	com.facebook.presto.execution.SqlQueryManager	Query complete	20160224_224410_00001_rjae5	FAILED	USER_ERROR	SYNTAX_ERROR:1	billg	594.74us	set session invalid.property.key='foo'
2016-02-24T14:44:25.726-0800	INFO	query-execution-2	com.facebook.presto.execution.SqlQueryManager	Query complete	20160224_224424_00002_rjae5	FINISHED	null	null	billg	811.80ms	show catalogs
```