### PR TITLE
Look up parquet columns by name case-insensitive

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/parquet/ParquetTypeUtils.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/parquet/ParquetTypeUtils.java
@@ -15,6 +15,7 @@ package com.facebook.presto.hive.parquet;
 
 import com.facebook.presto.hive.HiveColumnHandle;
 import parquet.schema.MessageType;
+import parquet.schema.Type;
 
 public final class ParquetTypeUtils
 {
@@ -27,6 +28,13 @@ public final class ParquetTypeUtils
         if (useParquetColumnNames) {
             if (messageType.containsField(column.getName())) {
                 return messageType.getType(column.getName());
+            }
+            // parquet is case-sensitive, but hive is not. all hive columns get converted to lowercase
+            // check for direct match above but if no match found, try case-insensitive match
+            for (Type type : messageType.getFields()) {
+                if (type.getName().equalsIgnoreCase(column.getName())) {
+                    return type;
+                }
             }
             return null;
         }


### PR DESCRIPTION
Parquet schema is case sensitive but hive is not so camelCase parquet fields are not found when accessed as lowercase hive columns.