### PR TITLE
Add event processer and handlers and scribe query completion events

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -730,6 +730,61 @@
                 <artifactId>hive-apache-jdbc</artifactId>
                 <version>0.13.1-1</version>
             </dependency>
+
+            <!-- twitter deps -->
+            <dependency>
+                <groupId>com.twitter</groupId>
+                <artifactId>presto-thrift-java</artifactId>
+                <version>0.0.1</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>com.twitter</groupId>
+                        <artifactId>util-core_2.11</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>com.twitter</groupId>
+                        <artifactId>util-core-java</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>com.twitter</groupId>
+                        <artifactId>util-function_2.10</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>com.twitter</groupId>
+                        <artifactId>util-function-java</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>commons-logging</groupId>
+                        <artifactId>commons-logging</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.scala-lang.modules</groupId>
+                        <artifactId>scala-parser-combinators_2.11</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+            <dependency>
+                <groupId>com.twitter</groupId>
+                <artifactId>util-logging_2.11</artifactId>
+                <version>6.33.0</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>commons-logging</groupId>
+                        <artifactId>commons-logging</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+            <dependency>
+                <groupId>org.scala-lang</groupId>
+                <artifactId>scala-library</artifactId>
+                <version>2.11.7</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>commons-logging</groupId>
+                        <artifactId>commons-logging</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 

--- a/presto-main/pom.xml
+++ b/presto-main/pom.xml
@@ -296,6 +296,24 @@
             <artifactId>tpch</artifactId>
             <scope>test</scope>
         </dependency>
+
+        <!-- twitter deps -->
+        <dependency>
+            <groupId>com.twitter</groupId>
+            <artifactId>presto-thrift-java</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.twitter</groupId>
+            <artifactId>util-logging_2.11</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.thrift</groupId>
+            <artifactId>libthrift</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.scala-lang</groupId>
+            <artifactId>scala-library</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/presto-main/src/main/java/com/facebook/presto/event/EventProcessor.java
+++ b/presto-main/src/main/java/com/facebook/presto/event/EventProcessor.java
@@ -18,7 +18,6 @@ import com.facebook.presto.event.query.QueryCreatedEvent;
 import com.facebook.presto.event.query.QueryEvent;
 import com.facebook.presto.event.query.QueryEventHandler;
 import com.facebook.presto.event.query.SplitCompletionEvent;
-import com.facebook.presto.twitter.logging.QueryLogger;
 import com.google.inject.Inject;
 import io.airlift.event.client.AbstractEventClient;
 import io.airlift.event.client.EventType;
@@ -35,7 +34,7 @@ public class EventProcessor extends AbstractEventClient
     private static final String QUERY_CREATED = "QueryCreated";
     private static final String QUERY_COMPLETION = "QueryCompletion";
     private static final String SPLIT_COMPLETION = "SplitCompletion";
-    private static final Logger log = Logger.get(QueryLogger.class);
+    private static final Logger log = Logger.get(EventProcessor.class);
 
     private Set<QueryEventHandler<QueryCreatedEvent>> queryCreatedEventHandlers;
     private Set<QueryEventHandler<QueryCompletionEvent>> queryCompletionEventHandlers;

--- a/presto-main/src/main/java/com/facebook/presto/event/EventProcessor.java
+++ b/presto-main/src/main/java/com/facebook/presto/event/EventProcessor.java
@@ -1,0 +1,90 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.event;
+
+import com.facebook.presto.event.query.QueryCompletionEvent;
+import com.facebook.presto.event.query.QueryCreatedEvent;
+import com.facebook.presto.event.query.QueryEvent;
+import com.facebook.presto.event.query.QueryEventHandler;
+import com.facebook.presto.event.query.SplitCompletionEvent;
+import com.facebook.presto.twitter.logging.QueryLogger;
+import com.google.inject.Inject;
+import io.airlift.event.client.AbstractEventClient;
+import io.airlift.event.client.EventType;
+import io.airlift.log.Logger;
+
+import java.io.IOException;
+import java.util.Set;
+
+public class EventProcessor extends AbstractEventClient
+{
+    private static final String QUERY_CREATED = "QueryCreated";
+    private static final String QUERY_COMPLETION = "QueryCompletion";
+    private static final String SPLIT_COMPLETION = "SplitCompletion";
+    private static final Logger log = Logger.get(QueryLogger.class);
+
+    private Set<QueryEventHandler<QueryCreatedEvent>> queryCreatedEventHandlers;
+    private Set<QueryEventHandler<QueryCompletionEvent>> queryCompletionEventHandlers;
+    private Set<QueryEventHandler<SplitCompletionEvent>> splitCompletionEventHandlers;
+
+    @Inject
+    public EventProcessor(
+            Set<QueryEventHandler<QueryCreatedEvent>> queryCreatedEventHandlers,
+            Set<QueryEventHandler<QueryCompletionEvent>> queryCompletionEventHandlers,
+            Set<QueryEventHandler<SplitCompletionEvent>> splitCompletionEventHandlers)
+    {
+        this.queryCreatedEventHandlers = queryCreatedEventHandlers;
+        this.queryCompletionEventHandlers = queryCompletionEventHandlers;
+        this.splitCompletionEventHandlers = splitCompletionEventHandlers;
+    }
+
+    @Override
+    protected <T> void postEvent(T event)
+            throws IOException
+    {
+        EventType eventTypeAnnotation = event.getClass().getAnnotation(EventType.class);
+        if (eventTypeAnnotation == null) {
+            return;
+        }
+
+        String type = eventTypeAnnotation.value();
+
+        switch (type) {
+            case QUERY_CREATED:
+                handle(queryCreatedEventHandlers, type, (QueryCreatedEvent) event);
+                break;
+            case QUERY_COMPLETION:
+                handle(queryCompletionEventHandlers, type, (QueryCompletionEvent) event);
+                break;
+            case SPLIT_COMPLETION:
+                handle(splitCompletionEventHandlers, type, (SplitCompletionEvent) event);
+                break;
+            default:
+                log.warn("Unrecognized event found: " + type);
+        }
+    }
+
+    private <E extends QueryEvent> void handle(Set<QueryEventHandler<E>> handlers, String type, E event)
+    {
+        for (QueryEventHandler<E> handler : handlers) {
+            try {
+                handler.handle(event);
+            }
+            catch (Throwable e) {
+                log.error(e, String.format(
+                        "Exception processing %s event for query %s", type, event.getQueryId()));
+            }
+        }
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/event/EventProcessor.java
+++ b/presto-main/src/main/java/com/facebook/presto/event/EventProcessor.java
@@ -27,6 +27,9 @@ import io.airlift.log.Logger;
 import java.io.IOException;
 import java.util.Set;
 
+/**
+ * Class that listens for airlift events and sends presto events to handlers
+ */
 public class EventProcessor extends AbstractEventClient
 {
     private static final String QUERY_CREATED = "QueryCreated";

--- a/presto-main/src/main/java/com/facebook/presto/event/query/QueryCompletionEvent.java
+++ b/presto-main/src/main/java/com/facebook/presto/event/query/QueryCompletionEvent.java
@@ -31,7 +31,7 @@ import java.util.List;
 
 @Immutable
 @EventType("QueryCompletion")
-public class QueryCompletionEvent
+public class QueryCompletionEvent implements QueryEvent
 {
     private final QueryId queryId;
     private final String transactionId;

--- a/presto-main/src/main/java/com/facebook/presto/event/query/QueryCreatedEvent.java
+++ b/presto-main/src/main/java/com/facebook/presto/event/query/QueryCreatedEvent.java
@@ -24,7 +24,7 @@ import java.net.URI;
 
 @Immutable
 @EventType("QueryCreated")
-public class QueryCreatedEvent
+public class QueryCreatedEvent implements QueryEvent
 {
     private final QueryId queryId;
     private final String transactionId;

--- a/presto-main/src/main/java/com/facebook/presto/event/query/QueryEvent.java
+++ b/presto-main/src/main/java/com/facebook/presto/event/query/QueryEvent.java
@@ -13,9 +13,6 @@
  */
 package com.facebook.presto.event.query;
 
-/**
- *
- */
 public interface QueryEvent
 {
     String getQueryId();

--- a/presto-main/src/main/java/com/facebook/presto/event/query/QueryEvent.java
+++ b/presto-main/src/main/java/com/facebook/presto/event/query/QueryEvent.java
@@ -1,0 +1,22 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.event.query;
+
+/**
+ *
+ */
+public interface QueryEvent
+{
+    String getQueryId();
+}

--- a/presto-main/src/main/java/com/facebook/presto/event/query/QueryEventHandler.java
+++ b/presto-main/src/main/java/com/facebook/presto/event/query/QueryEventHandler.java
@@ -1,0 +1,19 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.event.query;
+
+public interface QueryEventHandler<T extends QueryEvent>
+{
+    void handle(T event);
+}

--- a/presto-main/src/main/java/com/facebook/presto/event/query/SplitCompletionEvent.java
+++ b/presto-main/src/main/java/com/facebook/presto/event/query/SplitCompletionEvent.java
@@ -29,7 +29,7 @@ import static java.util.Objects.requireNonNull;
 
 @Immutable
 @EventType("SplitCompletion")
-public class SplitCompletionEvent
+public class SplitCompletionEvent implements QueryEvent
 {
     private final QueryId queryId;
     private final StageId stageId;

--- a/presto-main/src/main/java/com/facebook/presto/twitter/TwitterModuleLoader.java
+++ b/presto-main/src/main/java/com/facebook/presto/twitter/TwitterModuleLoader.java
@@ -13,10 +13,17 @@
  */
 package com.facebook.presto.twitter;
 
+import com.facebook.presto.event.EventProcessor;
+import com.facebook.presto.event.query.QueryCompletionEvent;
+import com.facebook.presto.event.query.QueryCreatedEvent;
+import com.facebook.presto.event.query.QueryEventHandler;
+import com.facebook.presto.event.query.SplitCompletionEvent;
 import com.facebook.presto.twitter.logging.QueryLogger;
+import com.facebook.presto.twitter.logging.QueryScriber;
 import com.google.common.collect.ImmutableList;
 import com.google.inject.Module;
 import com.google.inject.Scopes;
+import com.google.inject.TypeLiteral;
 import com.google.inject.multibindings.Multibinder;
 import io.airlift.event.client.EventClient;
 
@@ -37,10 +44,21 @@ public class TwitterModuleLoader
 
     public static Iterable<? extends Module> getAdditionalModules()
     {
-        return ImmutableList.of(binder ->
-                Multibinder.newSetBinder(binder, EventClient.class)
+        return ImmutableList.of(
+                binder -> Multibinder.newSetBinder(binder, EventClient.class)
                         .addBinding()
-                        .to(QueryLogger.class)
-                        .in(Scopes.SINGLETON));
+                        .to(EventProcessor.class)
+                        .in(Scopes.SINGLETON),
+                binder -> Multibinder.newSetBinder(binder, new TypeLiteral<QueryEventHandler<SplitCompletionEvent>>() {}),
+                binder -> Multibinder.newSetBinder(binder, new TypeLiteral<QueryEventHandler<QueryCreatedEvent>>() {}),
+                binder -> Multibinder.newSetBinder(binder, new TypeLiteral<QueryEventHandler<QueryCompletionEvent>>(){})
+                        .addBinding()
+                        .to(new TypeLiteral<QueryLogger>(){})
+                        .in(Scopes.SINGLETON),
+                binder -> Multibinder.newSetBinder(binder, new TypeLiteral<QueryEventHandler<QueryCompletionEvent>>(){})
+                        .addBinding()
+                        .to(QueryScriber.class)
+                        .in(Scopes.SINGLETON)
+                );
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/twitter/logging/QueryScriber.java
+++ b/presto-main/src/main/java/com/facebook/presto/twitter/logging/QueryScriber.java
@@ -13,13 +13,13 @@
  */
 package com.facebook.presto.twitter.logging;
 
+import com.facebook.presto.event.query.QueryCompletionEvent;
 import com.facebook.presto.event.query.QueryEventHandler;
 import com.google.common.base.Optional;
 import com.twitter.logging.BareFormatter$;
 import com.twitter.logging.Level;
 import com.twitter.logging.QueueingHandler;
 import com.twitter.logging.ScribeHandler;
-import com.twitter.presto.thriftjava.QueryCompletionEvent;
 import com.twitter.presto.thriftjava.QueryState;
 import io.airlift.log.Logger;
 import org.apache.thrift.TBase;
@@ -32,7 +32,7 @@ import java.util.logging.LogRecord;
 /**
  * Class that scribes query completion events
  */
-public class QueryScriber implements QueryEventHandler<com.facebook.presto.event.query.QueryCompletionEvent>
+public class QueryScriber implements QueryEventHandler<QueryCompletionEvent>
 {
     private static final String SCRIBE_CATEGORY = "test_presto_query_complete";
     private static final int MAX_QUEUE_SIZE = 1000;
@@ -66,7 +66,7 @@ public class QueryScriber implements QueryEventHandler<com.facebook.presto.event
     }
 
     @Override
-    public void handle(com.facebook.presto.event.query.QueryCompletionEvent event)
+    public void handle(QueryCompletionEvent event)
     {
         com.twitter.presto.thriftjava.QueryCompletionEvent thriftEvent = toThriftQueryCompletionEvent(event);
         Optional<String> message = serializeThriftToString(thriftEvent);
@@ -95,9 +95,10 @@ public class QueryScriber implements QueryEventHandler<com.facebook.presto.event
         }
     }
 
-    private static QueryCompletionEvent toThriftQueryCompletionEvent(com.facebook.presto.event.query.QueryCompletionEvent event)
+    private static com.twitter.presto.thriftjava.QueryCompletionEvent toThriftQueryCompletionEvent(QueryCompletionEvent event)
     {
-        QueryCompletionEvent thriftEvent = new QueryCompletionEvent();
+        com.twitter.presto.thriftjava.QueryCompletionEvent thriftEvent =
+                new com.twitter.presto.thriftjava.QueryCompletionEvent();
 
         thriftEvent.query_id = event.getQueryId();
         thriftEvent.transaction_id = event.getTransactionId();

--- a/presto-main/src/main/java/com/facebook/presto/twitter/logging/QueryScriber.java
+++ b/presto-main/src/main/java/com/facebook/presto/twitter/logging/QueryScriber.java
@@ -1,0 +1,169 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.twitter.logging;
+
+import com.facebook.presto.event.query.QueryCompletionEvent;
+import com.facebook.presto.event.query.QueryEventHandler;
+import com.google.common.base.Optional;
+import com.twitter.logging.BareFormatter$;
+import com.twitter.logging.Level;
+import com.twitter.logging.QueueingHandler;
+import com.twitter.logging.ScribeHandler;
+import com.twitter.presto.thriftjava.QueryState;
+import io.airlift.log.Logger;
+import org.apache.thrift.TBase;
+import org.apache.thrift.TException;
+import org.apache.thrift.TSerializer;
+
+import java.util.Base64;
+import java.util.logging.LogRecord;
+
+/**
+ * Class that scribes query completion events
+ */
+public class QueryScriber implements QueryEventHandler<QueryCompletionEvent>
+{
+    private static final String SCRIBE_CATEGORY = "test_presto_query_complete";
+    private static final int MAX_QUEUE_SIZE = 1000;
+
+    private static final Logger log = Logger.get(QueryScriber.class);
+
+    private QueueingHandler queueingHandler;
+
+    // TSerializer is not thread safe
+    private final ThreadLocal<TSerializer> serializer = new ThreadLocal<TSerializer>()
+    {
+        @Override protected TSerializer initialValue()
+        {
+          return new TSerializer();
+        }
+    };
+
+    public QueryScriber()
+    {
+        ScribeHandler scribeHandler = new ScribeHandler(
+                ScribeHandler.DefaultHostname(),
+                ScribeHandler.DefaultPort(),
+                SCRIBE_CATEGORY,
+                ScribeHandler.DefaultBufferTime(),
+                ScribeHandler.DefaultConnectBackoff(),
+                ScribeHandler.DefaultMaxMessagesPerTransaction(),
+                ScribeHandler.DefaultMaxMessagesToBuffer(),
+                BareFormatter$.MODULE$,
+                scala.Option.apply((Level) null));
+        queueingHandler = new QueueingHandler(scribeHandler, MAX_QUEUE_SIZE);
+    }
+
+    @Override
+    public void handle(QueryCompletionEvent event)
+    {
+        com.twitter.presto.thriftjava.QueryCompletionEvent thriftEvent = toThriftQueryCompletionEvent(event);
+        Optional<String> message = serializeThriftToString(thriftEvent);
+
+        if (message.isPresent()) {
+          LogRecord logRecord = new LogRecord(Level.ALL, message.get());
+          queueingHandler.publish(logRecord);
+        }
+        else {
+          log.warn("Unable to serialize QueryCompletionEvent: " + event);
+        }
+    }
+
+    /**
+    * Serialize a thrift object to bytes, compress, then encode as a base64 string.
+    */
+    private Optional<String> serializeThriftToString(TBase thriftMessage)
+    {
+        try {
+          return Optional.of(
+                  Base64.getEncoder().encodeToString(serializer.get().serialize(thriftMessage)));
+        }
+        catch (TException e) {
+            log.warn(e, "Could not serialize thrift object" + thriftMessage);
+          return Optional.absent();
+        }
+    }
+
+    private static com.twitter.presto.thriftjava.QueryCompletionEvent toThriftQueryCompletionEvent(QueryCompletionEvent event)
+    {
+        com.twitter.presto.thriftjava.QueryCompletionEvent thriftEvent =
+                new com.twitter.presto.thriftjava.QueryCompletionEvent();
+
+        thriftEvent.query_id = event.getQueryId();
+        thriftEvent.transaction_id = event.getTransactionId();
+        thriftEvent.user = event.getUser();
+        thriftEvent.principal = event.getPrincipal();
+        thriftEvent.source = event.getSource();
+        thriftEvent.server_version = event.getServerVersion();
+        thriftEvent.environment = event.getEnvironment();
+        thriftEvent.catalog = event.getCatalog();
+        thriftEvent.schema = event.getSchema();
+        thriftEvent.remote_client_address = event.getRemoteClientAddress();
+        thriftEvent.user_agent = event.getUserAgent();
+        thriftEvent.query_state = QueryState.valueOf(event.getQueryState());
+        thriftEvent.uri = event.getUri();
+        thriftEvent.field_names = event.getFieldNames();
+        thriftEvent.query = event.getQuery();
+        thriftEvent.create_time_ms = event.getCreateTime().getMillis();
+        thriftEvent.execution_start_time_ms = event.getExecutionStartTime().getMillis();
+        thriftEvent.end_time_ms = event.getEndTime().getMillis();
+        thriftEvent.queued_time_ms = event.getQueuedTimeMs();
+        if (event.getAnalysisTimeMs() != null) {
+            thriftEvent.analysis_time_ms = event.getAnalysisTimeMs();
+        }
+        if (event.getDistributedPlanningTimeMs() != null) {
+            thriftEvent.distributed_planning_time_ms = event.getDistributedPlanningTimeMs();
+        }
+        if (event.getTotalSplitWallTimeMs() != null) {
+            thriftEvent.total_split_wall_time_ms = event.getTotalSplitWallTimeMs();
+        }
+        if (event.getTotalSplitCpuTimeMs() != null) {
+            thriftEvent.total_split_cpu_time_ms = event.getTotalSplitCpuTimeMs();
+        }
+        if (event.getTotalBytes() != null) {
+            thriftEvent.total_bytes = event.getTotalBytes();
+        }
+        if (event.getTotalRows() != null) {
+            thriftEvent.total_rows = event.getTotalRows();
+        }
+        thriftEvent.splits = event.getSplits();
+        if (event.getErrorCode() != null) {
+            thriftEvent.error_code_id = event.getErrorCode();
+        }
+        thriftEvent.error_code_name = event.getErrorCodeName();
+        thriftEvent.failure_type = event.getFailureType();
+        thriftEvent.failure_message = event.getFailureMessage();
+        thriftEvent.failure_task = event.getFailureTask();
+        thriftEvent.failure_host = event.getFailureHost();
+        thriftEvent.output_stage_json = event.getOutputStageJson();
+        thriftEvent.failures_json = event.getFailuresJson();
+        thriftEvent.inputs_json = event.getInputsJson();
+        thriftEvent.session_properties_json = event.getSessionPropertiesJson();
+        thriftEvent.query_wall_time_ms = event.getQueryWallTimeMs();
+        if (event.getBytesPerSec() != null) {
+            thriftEvent.bytes_per_sec = event.getBytesPerSec();
+        }
+        if (event.getBytesPerCpuSec() != null) {
+            thriftEvent.bytes_per_cpu_sec = event.getBytesPerCpuSec();
+        }
+        if (event.getRowsPerSec() != null) {
+            thriftEvent.rows_per_sec = event.getRowsPerSec();
+        }
+        if (event.getRowsPerCpuSec() != null) {
+            thriftEvent.rows_per_cpu_sec = event.getRowsPerCpuSec();
+        }
+
+        return thriftEvent;
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/twitter/logging/QueryScriber.java
+++ b/presto-main/src/main/java/com/facebook/presto/twitter/logging/QueryScriber.java
@@ -13,13 +13,13 @@
  */
 package com.facebook.presto.twitter.logging;
 
-import com.facebook.presto.event.query.QueryCompletionEvent;
 import com.facebook.presto.event.query.QueryEventHandler;
 import com.google.common.base.Optional;
 import com.twitter.logging.BareFormatter$;
 import com.twitter.logging.Level;
 import com.twitter.logging.QueueingHandler;
 import com.twitter.logging.ScribeHandler;
+import com.twitter.presto.thriftjava.QueryCompletionEvent;
 import com.twitter.presto.thriftjava.QueryState;
 import io.airlift.log.Logger;
 import org.apache.thrift.TBase;
@@ -32,7 +32,7 @@ import java.util.logging.LogRecord;
 /**
  * Class that scribes query completion events
  */
-public class QueryScriber implements QueryEventHandler<QueryCompletionEvent>
+public class QueryScriber implements QueryEventHandler<com.facebook.presto.event.query.QueryCompletionEvent>
 {
     private static final String SCRIBE_CATEGORY = "test_presto_query_complete";
     private static final int MAX_QUEUE_SIZE = 1000;
@@ -66,17 +66,17 @@ public class QueryScriber implements QueryEventHandler<QueryCompletionEvent>
     }
 
     @Override
-    public void handle(QueryCompletionEvent event)
+    public void handle(com.facebook.presto.event.query.QueryCompletionEvent event)
     {
         com.twitter.presto.thriftjava.QueryCompletionEvent thriftEvent = toThriftQueryCompletionEvent(event);
         Optional<String> message = serializeThriftToString(thriftEvent);
 
         if (message.isPresent()) {
-          LogRecord logRecord = new LogRecord(Level.ALL, message.get());
-          queueingHandler.publish(logRecord);
+            LogRecord logRecord = new LogRecord(Level.ALL, message.get());
+            queueingHandler.publish(logRecord);
         }
         else {
-          log.warn("Unable to serialize QueryCompletionEvent: " + event);
+            log.warn("Unable to serialize QueryCompletionEvent: " + event);
         }
     }
 
@@ -95,10 +95,9 @@ public class QueryScriber implements QueryEventHandler<QueryCompletionEvent>
         }
     }
 
-    private static com.twitter.presto.thriftjava.QueryCompletionEvent toThriftQueryCompletionEvent(QueryCompletionEvent event)
+    private static QueryCompletionEvent toThriftQueryCompletionEvent(com.facebook.presto.event.query.QueryCompletionEvent event)
     {
-        com.twitter.presto.thriftjava.QueryCompletionEvent thriftEvent =
-                new com.twitter.presto.thriftjava.QueryCompletionEvent();
+        QueryCompletionEvent thriftEvent = new QueryCompletionEvent();
 
         thriftEvent.query_id = event.getQueryId();
         thriftEvent.transaction_id = event.getTransactionId();

--- a/presto-main/src/main/java/com/facebook/presto/twitter/logging/QueryScriber.java
+++ b/presto-main/src/main/java/com/facebook/presto/twitter/logging/QueryScriber.java
@@ -34,7 +34,7 @@ import java.util.logging.LogRecord;
  */
 public class QueryScriber implements QueryEventHandler<QueryCompletionEvent>
 {
-    private static final String SCRIBE_CATEGORY = "test_presto_query_complete";
+    private static final String SCRIBE_CATEGORY = "presto_query_complete";
     private static final int MAX_QUEUE_SIZE = 1000;
 
     private static final Logger log = Logger.get(QueryScriber.class);


### PR DESCRIPTION
Adding code to scribe log completion events along with a generic way to register event processors for QueryCreatedEvents, QueryCompletionEvents and SplitCompletionEvents. The parts not under the ```twitter```package  (and not the pom changes of course) could be contributed to OSS Presto. If not, those changes should move into the twitter-specific package.