### PR TITLE
add connection pool

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -645,6 +645,12 @@
             </dependency>
 
             <dependency>
+                <groupId>org.apache.commons</groupId>
+                <artifactId>commons-pool2</artifactId>
+                <version>2.4.2</version>
+            </dependency>
+
+            <dependency>
                 <groupId>commons-codec</groupId>
                 <artifactId>commons-codec</artifactId>
                 <version>1.9</version>

--- a/presto-hive/pom.xml
+++ b/presto-hive/pom.xml
@@ -97,6 +97,11 @@
         </dependency>
 
         <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-pool2</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>io.airlift</groupId>
             <artifactId>aircompressor</artifactId>
         </dependency>

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveClientModule.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveClientModule.java
@@ -31,6 +31,7 @@ import com.facebook.presto.spi.connector.ConnectorPageSinkProvider;
 import com.facebook.presto.spi.connector.ConnectorPageSourceProvider;
 import com.facebook.presto.spi.connector.ConnectorSplitManager;
 import com.facebook.presto.spi.type.TypeManager;
+import com.facebook.presto.twitter.hive.PooledHiveMetastoreClientFactory;
 import com.google.inject.Binder;
 import com.google.inject.Module;
 import com.google.inject.Provides;
@@ -99,6 +100,7 @@ public class HiveClientModule
         newExporter(binder).export(NamenodeStats.class).as(generatedNameOf(NamenodeStats.class));
 
         binder.bind(HiveMetastoreClientFactory.class).in(Scopes.SINGLETON);
+        binder.bind(PooledHiveMetastoreClientFactory.class).in(Scopes.SINGLETON);
 
         binder.bind(NodeManager.class).toInstance(nodeManager);
         binder.bind(TypeManager.class).toInstance(typeManager);

--- a/presto-hive/src/main/java/com/facebook/presto/twitter/hive/PooledHiveMetastoreClientFactory.java
+++ b/presto-hive/src/main/java/com/facebook/presto/twitter/hive/PooledHiveMetastoreClientFactory.java
@@ -21,7 +21,6 @@ import com.facebook.presto.twitter.hive.util.PooledTTransportFactory;
 import com.facebook.presto.twitter.hive.util.TTransportPool;
 import com.google.common.net.HostAndPort;
 import com.google.common.primitives.Ints;
-import io.airlift.log.Logger;
 import io.airlift.units.Duration;
 import org.apache.thrift.transport.TTransport;
 import org.apache.thrift.transport.TTransportException;
@@ -33,7 +32,6 @@ import static java.util.Objects.requireNonNull;
 
 public class PooledHiveMetastoreClientFactory
 {
-    private static final Logger log = Logger.get(PooledHiveMetastoreClientFactory.class);
     private final HostAndPort socksProxy;
     private final int timeoutMillis;
     private final HiveMetastoreAuthentication metastoreAuthentication;
@@ -61,7 +59,6 @@ public class PooledHiveMetastoreClientFactory
             if (transport == null) {
                 transport = transportPool.borrowObject(host, port, new PooledTTransportFactory(transportPool, host, port, socksProxy, timeoutMillis, metastoreAuthentication));
             }
-            log.debug("borrowed a transport for host: %s", host);
             return new ThriftHiveMetastoreClient(transport);
         }
         catch (Exception e) {

--- a/presto-hive/src/main/java/com/facebook/presto/twitter/hive/PooledHiveMetastoreClientFactory.java
+++ b/presto-hive/src/main/java/com/facebook/presto/twitter/hive/PooledHiveMetastoreClientFactory.java
@@ -38,7 +38,8 @@ public class PooledHiveMetastoreClientFactory
     private final HiveMetastoreAuthentication metastoreAuthentication;
     private final TTransportPool transportPool;
 
-    public PooledHiveMetastoreClientFactory(@Nullable HostAndPort socksProxy, Duration timeout, HiveMetastoreAuthentication metastoreAuthentication,
+    public PooledHiveMetastoreClientFactory(@Nullable HostAndPort socksProxy, Duration timeout,
+        HiveMetastoreAuthentication metastoreAuthentication,
         int maxTransport, long idleTimeout, long transportEvictInterval, int evictNumTests)
     {
         this.socksProxy = socksProxy;
@@ -54,10 +55,17 @@ public class PooledHiveMetastoreClientFactory
     }
 
     @Inject
-    public PooledHiveMetastoreClientFactory(HiveClientConfig config, ZookeeperServersetMetastoreConfig zkConfig, HiveMetastoreAuthentication metastoreAuthentication)
+    public PooledHiveMetastoreClientFactory(HiveClientConfig config,
+        ZookeeperServersetMetastoreConfig zkConfig,
+        HiveMetastoreAuthentication metastoreAuthentication)
     {
-        this(config.getMetastoreSocksProxy(), config.getMetastoreTimeout(), metastoreAuthentication,
-            zkConfig.getMaxTransport(), zkConfig.getTransportIdleTimeout(), zkConfig.getTransportEvictInterval(), zkConfig.getTransportEvictNumTests());
+        this(config.getMetastoreSocksProxy(),
+             config.getMetastoreTimeout(),
+             metastoreAuthentication,
+             zkConfig.getMaxTransport(),
+             zkConfig.getTransportIdleTimeout(),
+             zkConfig.getTransportEvictInterval(),
+             zkConfig.getTransportEvictNumTests());
     }
 
     public HiveMetastoreClient create(String host, int port)
@@ -66,7 +74,10 @@ public class PooledHiveMetastoreClientFactory
         try {
             TTransport transport = transportPool.borrowObject(host, port);
             if (transport == null) {
-                transport = transportPool.borrowObject(host, port, new PooledTTransportFactory(transportPool, host, port, socksProxy, timeoutMillis, metastoreAuthentication));
+                transport = transportPool.borrowObject(host, port,
+                    new PooledTTransportFactory(transportPool,
+                                                host, port, socksProxy,
+                                                timeoutMillis, metastoreAuthentication));
             }
             return new ThriftHiveMetastoreClient(transport);
         }

--- a/presto-hive/src/main/java/com/facebook/presto/twitter/hive/PooledHiveMetastoreClientFactory.java
+++ b/presto-hive/src/main/java/com/facebook/presto/twitter/hive/PooledHiveMetastoreClientFactory.java
@@ -21,6 +21,7 @@ import com.facebook.presto.twitter.hive.util.PooledTTransportFactory;
 import com.facebook.presto.twitter.hive.util.TTransportPool;
 import com.google.common.net.HostAndPort;
 import com.google.common.primitives.Ints;
+import io.airlift.log.Logger;
 import io.airlift.units.Duration;
 import org.apache.thrift.transport.TTransport;
 import org.apache.thrift.transport.TTransportException;
@@ -32,6 +33,7 @@ import static java.util.Objects.requireNonNull;
 
 public class PooledHiveMetastoreClientFactory
 {
+    private static final Logger log = Logger.get(PooledHiveMetastoreClientFactory.class);
     private final HostAndPort socksProxy;
     private final int timeoutMillis;
     private final HiveMetastoreAuthentication metastoreAuthentication;
@@ -59,6 +61,7 @@ public class PooledHiveMetastoreClientFactory
             if (transport == null) {
                 transport = transportPool.borrowObject(host, port, new PooledTTransportFactory(transportPool, host, port, socksProxy, timeoutMillis, metastoreAuthentication));
             }
+            log.debug("borrowed a transport for host: %s", host);
             return new ThriftHiveMetastoreClient(transport);
         }
         catch (Exception e) {

--- a/presto-hive/src/main/java/com/facebook/presto/twitter/hive/PooledHiveMetastoreClientFactory.java
+++ b/presto-hive/src/main/java/com/facebook/presto/twitter/hive/PooledHiveMetastoreClientFactory.java
@@ -56,7 +56,7 @@ public class PooledHiveMetastoreClientFactory
         try {
             TTransport transport= transportPool.borrowObject(host, port);
             if (transport == null) {
-                transport = transportPool.borrowObject(host, port, new PooledTTransportFactory(host, port, socksProxy, timeoutMillis, metastoreAuthentication));
+                transport = transportPool.borrowObject(host, port, new PooledTTransportFactory(transportPool, host, port, socksProxy, timeoutMillis, metastoreAuthentication));
             }
         }
         catch (Exception e) {

--- a/presto-hive/src/main/java/com/facebook/presto/twitter/hive/PooledHiveMetastoreClientFactory.java
+++ b/presto-hive/src/main/java/com/facebook/presto/twitter/hive/PooledHiveMetastoreClientFactory.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.twitter.hive;
+
+import com.facebook.presto.hive.HiveClientConfig;
+import com.facebook.presto.hive.ThriftHiveMetastoreClient;
+import com.facebook.presto.hive.authentication.HiveMetastoreAuthentication;
+import com.facebook.presto.hive.metastore.HiveMetastoreClient;
+import com.facebook.presto.twitter.hive.util.PooledTTransportFactory;
+import com.facebook.presto.twitter.hive.util.TTransportPool;
+import com.google.common.net.HostAndPort;
+import com.google.common.primitives.Ints;
+import io.airlift.units.Duration;
+import org.apache.thrift.transport.TTransport;
+import org.apache.thrift.transport.TTransportException;
+
+import javax.annotation.Nullable;
+import javax.inject.Inject;
+
+import static java.util.Objects.requireNonNull;
+
+public class PooledHiveMetastoreClientFactory
+{
+    private final HostAndPort socksProxy;
+    private final int timeoutMillis;
+    private final HiveMetastoreAuthentication metastoreAuthentication;
+
+    public PooledHiveMetastoreClientFactory(@Nullable HostAndPort socksProxy, Duration timeout, HiveMetastoreAuthentication metastoreAuthentication)
+    {
+        this.socksProxy = socksProxy;
+        this.timeoutMillis = Ints.checkedCast(timeout.toMillis());
+        this.metastoreAuthentication = requireNonNull(metastoreAuthentication, "metastoreAuthentication is null");
+        this.transportPool = new TTransportPool();
+    }
+
+    @Inject
+    public PooledHiveMetastoreClientFactory(HiveClientConfig config, HiveMetastoreAuthentication metastoreAuthentication)
+    {
+        this(config.getMetastoreSocksProxy(), config.getMetastoreTimeout(), metastoreAuthentication);
+    }
+
+    public HiveMetastoreClient create(String host, int port)
+            throws TTransportException
+    {
+        try {
+            TTransport transport= transportPool.borrowObject(host, port);
+            if (transport == null) {
+                transport = transportPool.borrowObject(host, port, new PooledTTransportFactory(host, port, socksProxy, timeoutMillis, metastoreAuthentication));
+            }
+        }
+        catch (Exception e) {
+            throw new TTransportException(e.getType(), String.format("%s: %s", host, e.getMessage()), e.getCause())
+        }
+        return new ThriftHiveMetastoreClient(transport);
+    }
+}

--- a/presto-hive/src/main/java/com/facebook/presto/twitter/hive/PooledHiveMetastoreClientFactory.java
+++ b/presto-hive/src/main/java/com/facebook/presto/twitter/hive/PooledHiveMetastoreClientFactory.java
@@ -35,6 +35,7 @@ public class PooledHiveMetastoreClientFactory
     private final HostAndPort socksProxy;
     private final int timeoutMillis;
     private final HiveMetastoreAuthentication metastoreAuthentication;
+    private final TTransportPool transportPool;
 
     public PooledHiveMetastoreClientFactory(@Nullable HostAndPort socksProxy, Duration timeout, HiveMetastoreAuthentication metastoreAuthentication)
     {
@@ -54,14 +55,14 @@ public class PooledHiveMetastoreClientFactory
             throws TTransportException
     {
         try {
-            TTransport transport= transportPool.borrowObject(host, port);
+            TTransport transport = transportPool.borrowObject(host, port);
             if (transport == null) {
                 transport = transportPool.borrowObject(host, port, new PooledTTransportFactory(transportPool, host, port, socksProxy, timeoutMillis, metastoreAuthentication));
             }
+            return new ThriftHiveMetastoreClient(transport);
         }
         catch (Exception e) {
-            throw new TTransportException(e.getType(), String.format("%s: %s", host, e.getMessage()), e.getCause())
+            throw new TTransportException(String.format("%s: %s", host, e.getMessage()), e.getCause());
         }
-        return new ThriftHiveMetastoreClient(transport);
     }
 }

--- a/presto-hive/src/main/java/com/facebook/presto/twitter/hive/ZookeeperServersetHiveCluster.java
+++ b/presto-hive/src/main/java/com/facebook/presto/twitter/hive/ZookeeperServersetHiveCluster.java
@@ -14,7 +14,6 @@
 package com.facebook.presto.twitter.hive;
 
 import com.facebook.presto.hive.HiveCluster;
-import com.facebook.presto.hive.HiveMetastoreClientFactory;
 import com.facebook.presto.hive.metastore.HiveMetastoreClient;
 import com.google.common.net.HostAndPort;
 import io.airlift.log.Logger;
@@ -31,11 +30,11 @@ public class ZookeeperServersetHiveCluster
         implements HiveCluster
 {
     private static final Logger log = Logger.get(ZookeeperServersetHiveCluster.class);
-    private final HiveMetastoreClientFactory clientFactory;
+    private final PooledHiveMetastoreClientFactory clientFactory;
     private ZookeeperMetastoreMonitor zkMetastoreMonitor;
 
     @Inject
-    public ZookeeperServersetHiveCluster(ZookeeperServersetMetastoreConfig config, HiveMetastoreClientFactory clientFactory)
+    public ZookeeperServersetHiveCluster(ZookeeperServersetMetastoreConfig config, PooledHiveMetastoreClientFactory clientFactory)
             throws Exception
     {
         String zkServerHostAndPort = requireNonNull(config.getZookeeperServerHostAndPort(), "zkServerHostAndPort is null");

--- a/presto-hive/src/main/java/com/facebook/presto/twitter/hive/ZookeeperServersetMetastoreConfig.java
+++ b/presto-hive/src/main/java/com/facebook/presto/twitter/hive/ZookeeperServersetMetastoreConfig.java
@@ -25,6 +25,10 @@ public class ZookeeperServersetMetastoreConfig
     private String zookeeperMetastorePath;
     private int zookeeperRetrySleepTime = 500; // ms
     private int zookeeperMaxRetries = 3;
+    private int maxTransport = 128;
+    private long transportIdleTimeout = 300_000L;
+    private long transportEvictInterval = 10_000L;
+    private int transportEvictNumTests = 3;
 
     public String getZookeeperServerHostAndPort()
     {
@@ -77,6 +81,56 @@ public class ZookeeperServersetMetastoreConfig
     public ZookeeperServersetMetastoreConfig setZookeeperMaxRetries(int zookeeperMaxRetries)
     {
         this.zookeeperMaxRetries = zookeeperMaxRetries;
+        return this;
+    }
+
+    @Min(1)
+    public int getMaxTransport()
+    {
+        return maxTransport;
+    }
+
+    @Config("hive.metastore.max-transport-num")
+    public ZookeeperServersetMetastoreConfig setMaxTransport(int maxTransport)
+    {
+        this.maxTransport = maxTransport;
+        return this;
+    }
+
+    public long getTransportIdleTimeout()
+    {
+        return transportIdleTimeout;
+    }
+
+    @Config("hive.metastore.transport-idle-timeout")
+    public ZookeeperServersetMetastoreConfig setTransportIdleTimeout(long transportIdleTimeout)
+    {
+        this.transportIdleTimeout = transportIdleTimeout;
+        return this;
+    }
+
+    public long getTransportEvictInterval()
+    {
+        return transportEvictInterval;
+    }
+
+    @Config("hive.metastore.transport-eviction-interval")
+    public ZookeeperServersetMetastoreConfig setTransportEvictInterval(long transportEvictInterval)
+    {
+        this.transportEvictInterval = transportEvictInterval;
+        return this;
+    }
+
+    @Min(0)
+    public int getTransportEvictNumTests()
+    {
+        return transportEvictNumTests;
+    }
+
+    @Config("hive.metastore.transport-eviction-num-tests")
+    public ZookeeperServersetMetastoreConfig setTransportEvictNumTests(int transportEvictNumTests)
+    {
+        this.transportEvictNumTests = transportEvictNumTests;
         return this;
     }
 }

--- a/presto-hive/src/main/java/com/facebook/presto/twitter/hive/util/PooledTTransportFactory.java
+++ b/presto-hive/src/main/java/com/facebook/presto/twitter/hive/util/PooledTTransportFactory.java
@@ -93,7 +93,7 @@ public class PooledTTransportFactory
         }
 
         log.debug("created a transport to: %s", host);
-        return new PooledTTransport(authenticatedTransport, pool);
+        return new PooledTTransport(authenticatedTransport, pool, HostAndPort.fromParts(host, port).toString());
     }
 
     @Override
@@ -133,13 +133,15 @@ public class PooledTTransportFactory
     private static class PooledTTransport
         extends TTransport
     {
+        private final String remote;
         private final TTransportPool pool;
         private final TTransport transport;
 
-        public PooledTTransport(TTransport transport, TTransportPool pool)
+        public PooledTTransport(TTransport transport, TTransportPool pool, String remote)
         {
             this.transport = transport;
             this.pool = pool;
+            this.remote = remote;
         }
 
         public TTransport getTTransport()
@@ -152,7 +154,7 @@ public class PooledTTransportFactory
         {
             log.debug("attempt to close a PooledTTransport, returning it to pool.");
             try {
-                pool.returnObject((TSocket) transport);
+                pool.returnObject(remote, (TSocket) transport);
             }
             catch (ClassCastException e) {
                 pool.returnObject(transport);

--- a/presto-hive/src/main/java/com/facebook/presto/twitter/hive/util/PooledTTransportFactory.java
+++ b/presto-hive/src/main/java/com/facebook/presto/twitter/hive/util/PooledTTransportFactory.java
@@ -33,9 +33,6 @@ import java.net.SocketException;
 
 import static java.util.Objects.requireNonNull;
 
-/**
- * Utility class to handle creating and caching the UserGroupInformation object.
- */
 public class PooledTTransportFactory
     extends BasePooledObjectFactory<TTransport>
 {
@@ -54,6 +51,12 @@ public class PooledTTransportFactory
         this.socksProxy = socksProxy;
         this.timeoutMillis = timeoutMillis;
         this.metastoreAuthentication = requireNonNull(metastoreAuthentication, "metastoreAuthentication is null");
+    }
+
+    @Override
+    public boolean validateObject(PooledObject<TTransport> pooledObject)
+    {
+        return pooledObject.getObject().isOpen();
     }
 
     @Override

--- a/presto-hive/src/main/java/com/facebook/presto/twitter/hive/util/PooledTTransportFactory.java
+++ b/presto-hive/src/main/java/com/facebook/presto/twitter/hive/util/PooledTTransportFactory.java
@@ -14,25 +14,175 @@
 package com.facebook.presto.twitter.hive.util;
 
 import com.facebook.presto.hive.authentication.HiveMetastoreAuthentication;
-
+import com.google.common.net.HostAndPort;
+import io.airlift.units.Duration;
 import javax.annotation.Nullable;
-
-import java.io.IOException;
-import java.net.InetSocketAddress
-import java.net.SocketAddress;
-import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentMap;
-
-import org.apache.commons.pool2.ObjectPool;
-import org.apache.commons.pool2.impl.GenericObjectPool;
+import org.apache.commons.pool2.PooledObject;
+import org.apache.commons.pool2.BasePooledObjectFactory;
+import org.apache.commons.pool2.impl.DefaultPooledObject;
 import org.apache.thrift.transport.TSocket;
 import org.apache.thrift.transport.TTransport;
+import org.apache.thrift.transport.TTransportException;
 
 /**
  * Utility class to handle creating and caching the UserGroupInformation object.
  */
 public class PooledTTransportFactory
+    extends BasePooledObjectFactory<TTransport>
 {
-    
+    private final TTransportPool pool;
+    private final String host;
+    private final int port;
+    private final HostAndPort socksProxy;
+    private final Duration timeoutMillis;
+    private final HiveMetastoreAuthentication metastoreAuthentication;
+
+    public PooledTTransportFactory(TTransportPool pool, String host, int port, @Nullable HostAndPort socksProxy, Duration timeoutMillis, HiveMetastoreAuthentication metastoreAuthentication)
+    {
+        this.pool = requireNonNull(pool, "pool is null");
+        this.host = requireNonNull(host, "host is null");
+        this.port = port;
+        this.socksProxy = socksProxy;
+        this.metastoreAuthentication = requireNonNull(metastoreAuthentication, "metastoreAuthentication is null");
+    }
+
+    @Override
+    public TTransport create()
+    {
+        return new PooledTTransport(Transport.create(host, port, socksProxy, timeoutMillis, metastoreAuthentication), pool);
+    }
+
+    @Override
+    public void destroyObject(PooledObject<TTransport> pooledTransport)
+    {
+        try {
+            ((PooledTTransport) pooledTransport.getObject()).getTTransport().close();
+        }
+        catch (TTransportException e) {
+            // ignored
+        }
+        pooledTransport.invalidate();
+    }
+
+    @Override
+    public PooledObject<TTransport> wrap(TTransport transport)
+        throws TTransportException
+    {
+        return new DefaultPooledObject<TTransport>(transport);
+    }
+
+    @Override
+    public void passivateObject(PooledObject<TTransport> pooledTransport)
+    {
+        try {
+            pooledTransport.getObject().flush();
+        }
+        catch (TTransportException e) {
+            destroyObject(pooledTransport);
+        }
+    }
+
+    private static class PooledTTransport
+        extends TTransport
+    {
+        private final TTransportPool pool;
+        private final TTransport transport;
+
+        public PooledTTransport(TTransport transport, TTransportPool, pool)
+        {
+            this.transport = transport;
+            this.pool = pool;
+        }
+
+        @Override
+        public void close()
+        {
+            pool.returnObject((TSocket) transport);
+        }
+
+        @Override
+        public TTransport.getTTransport()
+        {
+            return transport;
+        }
+
+        @Override
+        public boolean isOpen()
+        {
+            return transport.isOpen();
+        }
+
+        @Override
+        public boolean peek()
+        {
+            return transport.peek();
+        }
+
+        @Override
+        public byte[] getBuffer()
+        {
+            return transport.getBuffer();
+        }
+
+        @Override
+        public int getBufferPosition()
+        {
+            return transport.getBufferPosition();
+        }
+
+        @Override
+        public int getBytesRemainingInBuffer()
+        {
+            return transport.getBytesRemainingInBuffer();
+        }
+
+        @Override
+        public void consumeBuffer(int len)
+        {
+            transport.consumeBuffer(len);
+        }
+
+        @Override
+        public void open()
+                throws TTransportException
+        {
+            transport.open();
+        }
+
+        @Override
+        public int readAll(byte[] bytes, int off, int len)
+                throws TTransportException
+        {
+            return transport.readAll(bytes, off, len);
+        }
+
+        @Override
+        public int read(byte[] bytes, int off, int len)
+                throws TTransportException
+        {
+            return transport.read(bytes, off, len);
+        }
+
+        @Override
+        public void write(byte[] bytes)
+                throws TTransportException
+        {
+            transport.write(bytes);
+        }
+
+        @Override
+        public void write(byte[] bytes, int off, int len)
+                throws TTransportException
+        {
+            transport.write(bytes, off, len);
+        }
+
+        @Override
+        public void flush()
+                throws TTransportException
+        {
+            transport.flush();
+        }
+    }
+
 }

--- a/presto-hive/src/main/java/com/facebook/presto/twitter/hive/util/PooledTTransportFactory.java
+++ b/presto-hive/src/main/java/com/facebook/presto/twitter/hive/util/PooledTTransportFactory.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.twitter.hive.util;
+
+import com.facebook.presto.hive.authentication.HiveMetastoreAuthentication;
+
+import javax.annotation.Nullable;
+
+import java.io.IOException;
+import java.net.InetSocketAddress
+import java.net.SocketAddress;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+import org.apache.commons.pool2.ObjectPool;
+import org.apache.commons.pool2.impl.GenericObjectPool;
+import org.apache.thrift.transport.TSocket;
+import org.apache.thrift.transport.TTransport;
+
+/**
+ * Utility class to handle creating and caching the UserGroupInformation object.
+ */
+public class PooledTTransportFactory
+{
+    
+}

--- a/presto-hive/src/main/java/com/facebook/presto/twitter/hive/util/PooledTTransportFactory.java
+++ b/presto-hive/src/main/java/com/facebook/presto/twitter/hive/util/PooledTTransportFactory.java
@@ -151,7 +151,12 @@ public class PooledTTransportFactory
         public void close()
         {
             log.debug("attempt to close a PooledTTransport, returning it to pool.");
-            pool.returnObject(transport);
+            try {
+                pool.returnObject((TSocket) transport);
+            }
+            catch (ClassCastException e) {
+                pool.returnObject(transport);
+            }
         }
 
         @Override

--- a/presto-hive/src/main/java/com/facebook/presto/twitter/hive/util/PooledTTransportFactory.java
+++ b/presto-hive/src/main/java/com/facebook/presto/twitter/hive/util/PooledTTransportFactory.java
@@ -43,7 +43,9 @@ public class PooledTTransportFactory
     private final int timeoutMillis;
     private final HiveMetastoreAuthentication metastoreAuthentication;
 
-    public PooledTTransportFactory(TTransportPool pool, String host, int port, @Nullable HostAndPort socksProxy, int timeoutMillis, HiveMetastoreAuthentication metastoreAuthentication)
+    public PooledTTransportFactory(TTransportPool pool, String host, int port,
+        @Nullable HostAndPort socksProxy, int timeoutMillis,
+        HiveMetastoreAuthentication metastoreAuthentication)
     {
         this.pool = requireNonNull(pool, "pool is null");
         this.host = requireNonNull(host, "host is null");
@@ -68,7 +70,8 @@ public class PooledTTransportFactory
             transport = new TSocket(host, port, timeoutMillis);
         }
         else {
-            SocketAddress address = InetSocketAddress.createUnresolved(socksProxy.getHostText(), socksProxy.getPort());
+            SocketAddress address = InetSocketAddress.createUnresolved(socksProxy.getHostText(),
+                                                            socksProxy.getPort());
             Socket socket = new Socket(new Proxy(Proxy.Type.SOCKS, address));
             try {
                 socket.connect(InetSocketAddress.createUnresolved(host, port), timeoutMillis);
@@ -92,7 +95,8 @@ public class PooledTTransportFactory
             authenticatedTransport.open();
         }
 
-        return new PooledTTransport(authenticatedTransport, pool, HostAndPort.fromParts(host, port).toString());
+        return new PooledTTransport(authenticatedTransport, pool,
+                                    HostAndPort.fromParts(host, port).toString());
     }
 
     @Override

--- a/presto-hive/src/main/java/com/facebook/presto/twitter/hive/util/TTransportPool.java
+++ b/presto-hive/src/main/java/com/facebook/presto/twitter/hive/util/TTransportPool.java
@@ -14,7 +14,7 @@
 package com.facebook.presto.twitter.hive.util;
 
 import com.google.common.net.HostAndPort;
-import io.airlift.log.Logger;
+import io.airlift.units.Duration;
 import org.apache.commons.pool2.ObjectPool;
 import org.apache.commons.pool2.PooledObjectFactory;
 import org.apache.commons.pool2.impl.GenericObjectPool;
@@ -23,22 +23,27 @@ import org.apache.thrift.transport.TTransport;
 
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.TimeUnit;
 
 public class TTransportPool
 {
-    public static final Logger log = Logger.get(TTransportPool.class);
-    private static final int MAX_IDLE = 8;
     private static final int MIN_IDLE = 0;
     private static final int MAX_TOTAL = 128;
+    private static final int NUM_TESTS = 3;
+    private static final Duration IDLE_TIMEOUT = new Duration(300, TimeUnit.SECONDS);
+    private static final Duration EVICTION_INTERVEL = new Duration(10, TimeUnit.SECONDS);
     private final ConcurrentMap<String, ObjectPool<TTransport>> pools = new ConcurrentHashMap();
     private GenericObjectPoolConfig poolConfig;
 
     public TTransportPool()
     {
         poolConfig = new GenericObjectPoolConfig();
-        poolConfig.setMaxIdle(MAX_IDLE);
+        poolConfig.setMaxIdle(MAX_TOTAL);
         poolConfig.setMinIdle(MIN_IDLE);
         poolConfig.setMaxTotal(MAX_TOTAL);
+        poolConfig.setMinEvictableIdleTimeMillis(IDLE_TIMEOUT.toMillis());
+        poolConfig.setTimeBetweenEvictionRunsMillis(EVICTION_INTERVEL.toMillis());
+        poolConfig.setNumTestsPerEvictionRun(NUM_TESTS);
     }
 
     public TTransportPool(GenericObjectPoolConfig poolConfig)
@@ -69,11 +74,6 @@ public class TTransportPool
         if (pool == null) {
             return null;
         }
-        log.debug("Pool %s: mean wait time: %d millis, borrowed %d, idle %d.",
-                    remote,
-                    ((GenericObjectPool) pool).getMeanBorrowWaitTimeMillis(),
-                    ((GenericObjectPool) pool).getNumActive(),
-                    ((GenericObjectPool) pool).getNumIdle());
         return pool.borrowObject();
     }
 
@@ -104,6 +104,7 @@ public class TTransportPool
             pool.returnObject(pooledTransport);
         }
         catch (Exception e) {
+            transport.close();
         }
     }
 

--- a/presto-hive/src/main/java/com/facebook/presto/twitter/hive/util/TTransportPool.java
+++ b/presto-hive/src/main/java/com/facebook/presto/twitter/hive/util/TTransportPool.java
@@ -14,7 +14,6 @@
 package com.facebook.presto.twitter.hive.util;
 
 import com.google.common.net.HostAndPort;
-import io.airlift.units.Duration;
 import org.apache.commons.pool2.ObjectPool;
 import org.apache.commons.pool2.PooledObjectFactory;
 import org.apache.commons.pool2.impl.GenericObjectPool;
@@ -23,28 +22,11 @@ import org.apache.thrift.transport.TTransport;
 
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
-import java.util.concurrent.TimeUnit;
 
 public class TTransportPool
 {
-    private static final int MIN_IDLE = 0;
-    private static final int MAX_TOTAL = 128;
-    private static final int NUM_TESTS = 3;
-    private static final Duration IDLE_TIMEOUT = new Duration(300, TimeUnit.SECONDS);
-    private static final Duration EVICTION_INTERVAL = new Duration(10, TimeUnit.SECONDS);
     private final ConcurrentMap<String, ObjectPool<TTransport>> pools = new ConcurrentHashMap();
     private GenericObjectPoolConfig poolConfig;
-
-    public TTransportPool()
-    {
-        poolConfig = new GenericObjectPoolConfig();
-        poolConfig.setMaxIdle(MAX_TOTAL);
-        poolConfig.setMinIdle(MIN_IDLE);
-        poolConfig.setMaxTotal(MAX_TOTAL);
-        poolConfig.setMinEvictableIdleTimeMillis(IDLE_TIMEOUT.toMillis());
-        poolConfig.setTimeBetweenEvictionRunsMillis(EVICTION_INTERVAL.toMillis());
-        poolConfig.setNumTestsPerEvictionRun(NUM_TESTS);
-    }
 
     public TTransportPool(GenericObjectPoolConfig poolConfig)
     {

--- a/presto-hive/src/main/java/com/facebook/presto/twitter/hive/util/TTransportPool.java
+++ b/presto-hive/src/main/java/com/facebook/presto/twitter/hive/util/TTransportPool.java
@@ -1,0 +1,108 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.twitter.hive.util;
+
+import com.facebook.presto.hive.authentication.HiveMetastoreAuthentication;
+
+import javax.annotation.Nullable;
+
+import java.io.IOException;
+import java.net.InetSocketAddress
+import java.net.SocketAddress;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+import org.apache.commons.pool2.ObjectPool;
+import org.apache.commons.pool2.impl.GenericObjectPool;
+import org.apache.thrift.transport.TSocket;
+import org.apache.thrift.transport.TTransport;
+
+/**
+ * Utility class to handle creating and caching the UserGroupInformation object.
+ */
+public class TTransportPool
+{
+    private final ConcurrentMap<SocketAddress, ObjectPool<TTransport>> pools = new ConcurrentHashMap();
+
+    public TTransportPool(){}
+
+    private void add(SocketAddress remote, PooledObjectFactory transportFactory)
+    {
+        pools.put(remote, new GenericObjectPool<TTransport>(transportFactory));
+    }
+
+    protected TTransport get(SocketAddress remote, PooledObjectFactory transportFactory)
+    {
+        ObjectPool<TTransport> pool = pools.get(remote)
+        if (pool == null)
+        {
+            add(remote, transportFactory);
+            pool = pools.get(remote);
+        }
+
+        return pool.borrowObject();
+    }
+
+    protected TTransport get(SocketAddress remote)
+    {
+        ObjectPool<TTransport> pool = pools.get(remote)
+        if (pool == null)
+        {
+            return null;
+        }
+
+        return pool.borrowObject();
+    }
+
+    public TTransport borrowObject(String host, int port, PooledObjectFactory transportFactory)
+    {
+        return get(InetSocketAddress.createUnresolved(host, port), transportFactory);
+    }
+
+    public TTransport borrowObject(String host, int port)
+    {
+        return get(InetSocketAddress.createUnresolved(host, port));
+    }
+
+    private static void closeQuietly(Closeable closeable)
+    {
+        try {
+            closeable.close();
+        }
+        catch (IOException e) {
+            // ignored
+        }
+    }
+
+    public void returnObject(TSocket socket)
+    {
+        SocketAddress remote = socket.getSocket().getRemoteSocketAddress()
+        if (remote == null)
+        {
+            return closeQuietly(socket);
+        }
+        ObjectPool<TTransport> pool = pools.get(remote);
+        if (pool == null)
+        {
+            return closeQuietly(socket);
+        }
+        pool.returnObject(socket);
+    }
+
+    public void returnObject(TTransport transport)
+    {
+        return closeQuietly(transport);
+    }
+}

--- a/presto-hive/src/main/java/com/facebook/presto/twitter/hive/util/TTransportPool.java
+++ b/presto-hive/src/main/java/com/facebook/presto/twitter/hive/util/TTransportPool.java
@@ -31,7 +31,7 @@ public class TTransportPool
     private static final int MAX_TOTAL = 128;
     private static final int NUM_TESTS = 3;
     private static final Duration IDLE_TIMEOUT = new Duration(300, TimeUnit.SECONDS);
-    private static final Duration EVICTION_INTERVEL = new Duration(10, TimeUnit.SECONDS);
+    private static final Duration EVICTION_INTERVAL = new Duration(10, TimeUnit.SECONDS);
     private final ConcurrentMap<String, ObjectPool<TTransport>> pools = new ConcurrentHashMap();
     private GenericObjectPoolConfig poolConfig;
 
@@ -42,7 +42,7 @@ public class TTransportPool
         poolConfig.setMinIdle(MIN_IDLE);
         poolConfig.setMaxTotal(MAX_TOTAL);
         poolConfig.setMinEvictableIdleTimeMillis(IDLE_TIMEOUT.toMillis());
-        poolConfig.setTimeBetweenEvictionRunsMillis(EVICTION_INTERVEL.toMillis());
+        poolConfig.setTimeBetweenEvictionRunsMillis(EVICTION_INTERVAL.toMillis());
         poolConfig.setNumTestsPerEvictionRun(NUM_TESTS);
     }
 

--- a/presto-hive/src/main/java/com/facebook/presto/twitter/hive/util/TTransportPool.java
+++ b/presto-hive/src/main/java/com/facebook/presto/twitter/hive/util/TTransportPool.java
@@ -18,7 +18,7 @@ import com.facebook.presto.hive.authentication.HiveMetastoreAuthentication;
 import javax.annotation.Nullable;
 
 import java.io.IOException;
-import java.net.InetSocketAddress
+import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;

--- a/presto-hive/src/main/java/com/facebook/presto/twitter/hive/util/TTransportPool.java
+++ b/presto-hive/src/main/java/com/facebook/presto/twitter/hive/util/TTransportPool.java
@@ -51,20 +51,16 @@ public class TTransportPool
         this.poolConfig = poolConfig;
     }
 
-    private void add(String remote, PooledObjectFactory transportFactory)
+    protected synchronized void add(String remote, PooledObjectFactory transportFactory)
     {
-        pools.put(remote, new GenericObjectPool<TTransport>(transportFactory, poolConfig));
+        pools.putIfAbsent(remote, new GenericObjectPool<TTransport>(transportFactory, poolConfig));
     }
 
     protected TTransport get(String remote, PooledObjectFactory transportFactory)
         throws Exception
     {
-        ObjectPool<TTransport> pool = pools.get(remote);
-        if (pool == null) {
-            add(remote, transportFactory);
-            pool = pools.get(remote);
-        }
-        return pool.borrowObject();
+        add(remote, transportFactory);
+        return get(remote);
     }
 
     protected TTransport get(String remote)

--- a/presto-hive/src/main/java/com/facebook/presto/twitter/hive/util/TTransportPool.java
+++ b/presto-hive/src/main/java/com/facebook/presto/twitter/hive/util/TTransportPool.java
@@ -29,7 +29,7 @@ public class TTransportPool
     public static final Logger log = Logger.get(TTransportPool.class);
     private static final int MAX_IDLE = 8;
     private static final int MIN_IDLE = 0;
-    private static final int MAX_TOTAL = 100;
+    private static final int MAX_TOTAL = 128;
     private final ConcurrentMap<String, ObjectPool<TTransport>> pools = new ConcurrentHashMap();
     private GenericObjectPoolConfig poolConfig;
 
@@ -69,7 +69,11 @@ public class TTransportPool
         if (pool == null) {
             return null;
         }
-        log.debug("The mean borrow wait time for %s is %d millis", remote, ((GenericObjectPool) pool).getMeanBorrowWaitTimeMillis());
+        log.debug("Pool %s: mean wait time: %d millis, borrowed %d, idle %d.",
+                    remote,
+                    ((GenericObjectPool) pool).getMeanBorrowWaitTimeMillis(),
+                    ((GenericObjectPool) pool).getNumActive(),
+                    ((GenericObjectPool) pool).getNumIdle());
         return pool.borrowObject();
     }
 

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestingHiveCluster.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestingHiveCluster.java
@@ -15,7 +15,6 @@ package com.facebook.presto.hive;
 
 import com.facebook.presto.hive.authentication.NoHiveMetastoreAuthentication;
 import com.facebook.presto.hive.metastore.HiveMetastoreClient;
-import com.facebook.presto.twitter.hive.PooledHiveMetastoreClientFactory;
 import com.google.common.base.Throwables;
 import org.apache.thrift.transport.TTransportException;
 
@@ -41,7 +40,7 @@ public class TestingHiveCluster
     public HiveMetastoreClient createMetastoreClient()
     {
         try {
-            return new PooledHiveMetastoreClientFactory(config, new NoHiveMetastoreAuthentication()).create(host, port);
+            return new HiveMetastoreClientFactory(config, new NoHiveMetastoreAuthentication()).create(host, port);
         }
         catch (TTransportException e) {
             throw Throwables.propagate(e);

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestingHiveCluster.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestingHiveCluster.java
@@ -15,6 +15,7 @@ package com.facebook.presto.hive;
 
 import com.facebook.presto.hive.authentication.NoHiveMetastoreAuthentication;
 import com.facebook.presto.hive.metastore.HiveMetastoreClient;
+import com.facebook.presto.twitter.hive.PooledHiveMetastoreClientFactory;
 import com.google.common.base.Throwables;
 import org.apache.thrift.transport.TTransportException;
 
@@ -40,7 +41,7 @@ public class TestingHiveCluster
     public HiveMetastoreClient createMetastoreClient()
     {
         try {
-            return new HiveMetastoreClientFactory(config, new NoHiveMetastoreAuthentication()).create(host, port);
+            return new PooledHiveMetastoreClientFactory(config, new NoHiveMetastoreAuthentication()).create(host, port);
         }
         catch (TTransportException e) {
             throw Throwables.propagate(e);

--- a/presto-hive/src/test/java/com/facebook/presto/twitter/hive/TestZookeeperServersetMetastoreConfig.java
+++ b/presto-hive/src/test/java/com/facebook/presto/twitter/hive/TestZookeeperServersetMetastoreConfig.java
@@ -31,7 +31,11 @@ public class TestZookeeperServersetMetastoreConfig
                 .setZookeeperMaxRetries(3)
                 .setZookeeperRetrySleepTime(500)
                 .setZookeeperMetastorePath(null)
-                .setZookeeperServerHostAndPort(null));
+                .setZookeeperServerHostAndPort(null)
+                .setMaxTransport(128)
+                .setTransportIdleTimeout(300_000L)
+                .setTransportEvictInterval(10_000L)
+                .setTransportEvictNumTests(3));
     }
 
     @Test
@@ -42,13 +46,21 @@ public class TestZookeeperServersetMetastoreConfig
                 .put("hive.metastore.zookeeper.path", "/zookeeper/path/")
                 .put("hive.metastore.zookeeper.retry.sleeptime", "200")
                 .put("hive.metastore.zookeeper.max.retries", "2")
+                .put("hive.metastore.max-transport-num", "64")
+                .put("hive.metastore.transport-idle-timeout", "100000")
+                .put("hive.metastore.transport-eviction-interval", "1000")
+                .put("hive.metastore.transport-eviction-num-tests", "10")
                 .build();
 
         ZookeeperServersetMetastoreConfig expected = new ZookeeperServersetMetastoreConfig()
                 .setZookeeperServerHostAndPort("localhost:2181")
                 .setZookeeperMetastorePath("/zookeeper/path/")
                 .setZookeeperRetrySleepTime(200)
-                .setZookeeperMaxRetries(2);
+                .setZookeeperMaxRetries(2)
+                .setMaxTransport(64)
+                .setTransportIdleTimeout(100_000L)
+                .setTransportEvictInterval(1_000L)
+                .setTransportEvictNumTests(10);
 
         assertFullMapping(properties, expected);
     }


### PR DESCRIPTION
Even if we set the socket native "so_reuseaddr" flag to true, we still need to explicitly bind the local address. Therefore we have to have a port pool to record which ports are used for connecting hive metastore. This working prototype of pooling TTransport is proposed to avoid reallocate and reconnect socket.

The connection number end at 8 for each single metastore instance for 10 concurrent queries in "devel". It approximately uses the same runtime comparing without a connection pool. If this approach is favored, It can come with more settings for abandoning, idle connections and much more. 