### PR TITLE
Parquet schema evolution on non-primitive type

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveCoercionPolicy.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveCoercionPolicy.java
@@ -25,6 +25,9 @@ import static com.facebook.presto.hive.HiveType.HIVE_INT;
 import static com.facebook.presto.hive.HiveType.HIVE_LONG;
 import static com.facebook.presto.hive.HiveType.HIVE_SHORT;
 import static java.util.Objects.requireNonNull;
+import static org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector.Category.LIST;
+import static org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector.Category.MAP;
+import static org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector.Category.STRUCT;
 
 public class HiveCoercionPolicy
         implements CoercionPolicy
@@ -40,6 +43,10 @@ public class HiveCoercionPolicy
     @Override
     public boolean canCoerce(HiveType fromHiveType, HiveType toHiveType)
     {
+        if (fromHiveType.getCategory() == MAP || fromHiveType.getCategory() == LIST || fromHiveType.getCategory() == STRUCT) {
+            return fromHiveType.getCategory().equals(toHiveType.getCategory());
+        }
+
         Type fromType = typeManager.getType(fromHiveType.getTypeSignature());
         Type toType = typeManager.getType(toHiveType.getTypeSignature());
         if (fromType instanceof VarcharType) {

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveCoercionRecordCursor.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveCoercionRecordCursor.java
@@ -14,6 +14,7 @@
 package com.facebook.presto.hive;
 
 import com.facebook.presto.hive.HivePageSourceProvider.ColumnMapping;
+import com.facebook.presto.hive.parquet.ParquetHiveRecordCursor;
 import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.RecordCursor;
 import com.facebook.presto.spi.type.Type;
@@ -64,6 +65,10 @@ public class HiveCoercionRecordCursor
             ColumnMapping columnMapping = columnMappings.get(columnIndex);
 
             if (columnMapping.getCoercionFrom().isPresent()) {
+                // skip non-primitive coercion for Parquet
+                if (delegate instanceof ParquetHiveRecordCursor && !columnMapping.isFromPrimitiveType()) {
+                    continue;
+                }
                 coercers[columnIndex] = createCoercer(typeManager, columnMapping.getCoercionFrom().get(), columnMapping.getHiveColumnHandle().getHiveType());
             }
         }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HivePageSourceProvider.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HivePageSourceProvider.java
@@ -13,6 +13,8 @@
  */
 package com.facebook.presto.hive;
 
+import com.facebook.presto.hive.parquet.ParquetPageSourceFactory;
+import com.facebook.presto.hive.parquet.ParquetRecordCursorProvider;
 import com.facebook.presto.spi.ColumnHandle;
 import com.facebook.presto.spi.ConnectorPageSource;
 import com.facebook.presto.spi.ConnectorSession;
@@ -51,6 +53,7 @@ import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.collect.Maps.uniqueIndex;
 import static java.util.Objects.requireNonNull;
 import static java.util.stream.Collectors.toList;
+import static org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector.Category.PRIMITIVE;
 
 public class HivePageSourceProvider
         implements ConnectorPageSourceProvider
@@ -149,6 +152,9 @@ public class HivePageSourceProvider
         List<ColumnMapping> regularColumnMappings = ColumnMapping.extractRegularColumnMappings(columnMappings);
 
         for (HivePageSourceFactory pageSourceFactory : pageSourceFactories) {
+            // only Parquet support flexible non-primitive converter in its cursor
+            boolean doCoercionOnNonPrimitive = !(pageSourceFactory instanceof ParquetPageSourceFactory);
+
             Optional<? extends ConnectorPageSource> pageSource = pageSourceFactory.createPageSource(
                     configuration,
                     session,
@@ -156,7 +162,7 @@ public class HivePageSourceProvider
                     start,
                     length,
                     schema,
-                    extractRegularColumnHandles(regularColumnMappings, true),
+                    extractRegularColumnHandles(regularColumnMappings, true, doCoercionOnNonPrimitive),
                     effectivePredicate,
                     hiveStorageTimeZone
             );
@@ -173,6 +179,8 @@ public class HivePageSourceProvider
         for (HiveRecordCursorProvider provider : cursorProviders) {
             // GenericHiveRecordCursor will automatically do the coercion without HiveCoercionRecordCursor
             boolean doCoercion = !(provider instanceof GenericHiveRecordCursorProvider);
+            // only Parquet support non-primitive coercion without HiveCoercionRecordCursor
+            boolean doCoercionOnNonPrimitive = !(provider instanceof ParquetRecordCursorProvider);
 
             Optional<RecordCursor> cursor = provider.createRecordCursor(
                     clientId,
@@ -182,7 +190,7 @@ public class HivePageSourceProvider
                     start,
                     length,
                     schema,
-                    extractRegularColumnHandles(regularColumnMappings, doCoercion),
+                    extractRegularColumnHandles(regularColumnMappings, doCoercion, doCoercionOnNonPrimitive),
                     effectivePredicate,
                     hiveStorageTimeZone,
                     typeManager);
@@ -261,6 +269,12 @@ public class HivePageSourceProvider
             return coercionFrom;
         }
 
+        public boolean isFromPrimitiveType()
+        {
+            checkState(coercionFrom.isPresent(), "coercionFrom is not present");
+            return coercionFrom.get().getCategory() == PRIMITIVE;
+        }
+
         private static boolean isPrefilled(HiveColumnHandle hiveColumnHandle)
         {
             return hiveColumnHandle.getColumnType() != REGULAR;
@@ -305,12 +319,15 @@ public class HivePageSourceProvider
                     .collect(toList());
         }
 
-        public static List<HiveColumnHandle> extractRegularColumnHandles(List<ColumnMapping> regularColumnMappings, boolean doCoercion)
+        public static List<HiveColumnHandle> extractRegularColumnHandles(List<ColumnMapping> regularColumnMappings, boolean doCoercion, boolean doCoercionOnNonPrimitive)
         {
             return regularColumnMappings.stream()
                     .map(columnMapping -> {
                         HiveColumnHandle columnHandle = columnMapping.getHiveColumnHandle();
                         if (!doCoercion || !columnMapping.getCoercionFrom().isPresent()) {
+                            return columnHandle;
+                        }
+                        if (!columnMapping.isFromPrimitiveType() && !doCoercionOnNonPrimitive) {
                             return columnHandle;
                         }
                         return new HiveColumnHandle(columnHandle.getClientId(),

--- a/presto-hive/src/main/java/com/facebook/presto/hive/parquet/ParquetHiveRecordCursor.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/parquet/ParquetHiveRecordCursor.java
@@ -22,13 +22,16 @@ import com.facebook.presto.spi.RecordCursor;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
 import com.facebook.presto.spi.block.BlockBuilderStatus;
+import com.facebook.presto.spi.block.InterleavedBlockBuilder;
 import com.facebook.presto.spi.predicate.TupleDomain;
 import com.facebook.presto.spi.type.DecimalType;
 import com.facebook.presto.spi.type.Decimals;
+import com.facebook.presto.spi.type.NamedTypeSignature;
 import com.facebook.presto.spi.type.Type;
 import com.facebook.presto.spi.type.TypeManager;
 import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableList;
+
 import io.airlift.slice.Slice;
 import it.unimi.dsi.fastutil.longs.LongArrayList;
 import org.apache.hadoop.conf.Configuration;
@@ -59,6 +62,7 @@ import java.io.IOException;
 import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -334,7 +338,7 @@ public class ParquetHiveRecordCursor
             FileMetaData fileMetaData = parquetMetadata.getFileMetaData();
             MessageType fileSchema = fileMetaData.getSchema();
 
-            PrestoReadSupport readSupport = new PrestoReadSupport(useParquetColumnNames, columns, fileSchema);
+            PrestoReadSupport readSupport = new PrestoReadSupport(useParquetColumnNames, columns, fileSchema, typeManager);
 
             List<parquet.schema.Type> fields = columns.stream()
                     .filter(column -> column.getColumnType() == REGULAR)
@@ -411,7 +415,7 @@ public class ParquetHiveRecordCursor
         private final List<HiveColumnHandle> columns;
         private final List<Converter> converters;
 
-        public PrestoReadSupport(boolean useParquetColumnNames, List<HiveColumnHandle> columns, MessageType messageType)
+        public PrestoReadSupport(boolean useParquetColumnNames, List<HiveColumnHandle> columns, MessageType messageType, TypeManager typeManager)
         {
             this.columns = columns;
             this.useParquetColumnNames = useParquetColumnNames;
@@ -434,7 +438,7 @@ public class ParquetHiveRecordCursor
                         }
                     }
                     else {
-                        converters.add(new ParquetColumnConverter(createGroupConverter(types[i], parquetType.getName(), parquetType, i), i));
+                        converters.add(new ParquetColumnConverter(createGroupConverter(types[i], parquetType.getName(), parquetType, i, useParquetColumnNames, typeManager), i));
                     }
                 }
             }
@@ -687,40 +691,74 @@ public class ParquetHiveRecordCursor
         void afterValue();
     }
 
+    private interface IndexedBlockConverter extends BlockConverter
+    {
+        void setFieldIndex(int fieldIndex);
+        int getFieldIndex();
+        Type getType();
+    }
+
     private abstract static class GroupedConverter
             extends GroupConverter
-            implements BlockConverter
+            implements IndexedBlockConverter
     {
         public abstract Block getBlock();
     }
 
-    private static BlockConverter createConverter(Type prestoType, String columnName, parquet.schema.Type parquetType, int fieldIndex)
+    private static IndexedBlockConverter createConverter(Type prestoType, String columnName, parquet.schema.Type parquetType, int fieldIndex, boolean useNames, TypeManager typeManager)
     {
         if (parquetType.isPrimitive()) {
             if (parquetType.getOriginalType() == DECIMAL) {
                 DecimalMetadata decimalMetadata = ((PrimitiveType) parquetType).getDecimalMetadata();
-                return new ParquetDecimalConverter(createDecimalType(decimalMetadata.getPrecision(), decimalMetadata.getScale()));
+                return new ParquetDecimalConverter(createDecimalType(decimalMetadata.getPrecision(), decimalMetadata.getScale()), fieldIndex);
             }
             else {
                 return new ParquetPrimitiveConverter(prestoType, fieldIndex);
             }
         }
 
-        return createGroupConverter(prestoType, columnName, parquetType, fieldIndex);
+        return createGroupConverter(prestoType, columnName, parquetType, fieldIndex, useNames, typeManager);
     }
 
-    private static GroupedConverter createGroupConverter(Type prestoType, String columnName, parquet.schema.Type parquetType, int fieldIndex)
+    private static GroupedConverter createGroupConverter(Type prestoType, String columnName, parquet.schema.Type parquetType, int fieldIndex, boolean useNames, TypeManager typeManager)
     {
         GroupType groupType = parquetType.asGroupType();
         switch (prestoType.getTypeSignature().getBase()) {
             case ARRAY:
-                return new ParquetListConverter(prestoType, columnName, groupType, fieldIndex);
+                return new ParquetListConverter(prestoType, columnName, groupType, fieldIndex, useNames, typeManager);
             case MAP:
-                return new ParquetMapConverter(prestoType, columnName, groupType, fieldIndex);
+                return new ParquetMapConverter(prestoType, columnName, groupType, fieldIndex, useNames, typeManager);
             case ROW:
-                return new ParquetStructConverter(prestoType, columnName, groupType, fieldIndex);
+                return new ParquetStructConverter(prestoType, columnName, groupType, fieldIndex, useNames, typeManager);
             default:
                 throw new IllegalArgumentException("Column " + columnName + " type " + parquetType.getOriginalType() + " not supported");
+        }
+    }
+
+    private static class FieldInformation
+    {
+        private final Type type;
+        private final int index;
+
+        private FieldInformation(int index, Type type)
+        {
+            this.index = index;
+            this.type = type;
+        }
+
+        static FieldInformation of(int index, Type type)
+        {
+            return new FieldInformation(index, type);
+        }
+
+        public Type getType()
+        {
+            return type;
+        }
+
+        public int getIndex()
+        {
+            return index;
         }
     }
 
@@ -731,34 +769,106 @@ public class ParquetHiveRecordCursor
         private static final int NULL_BUILDER_SIZE_IN_BYTES_THRESHOLD = 32768;
 
         private final Type rowType;
-        private final int fieldIndex;
+        private int fieldIndex;
 
-        private final List<BlockConverter> converters;
+        private final List<IndexedBlockConverter> converters;
         private BlockBuilder builder;
         private BlockBuilder nullBuilder; // used internally when builder is set to null
         private BlockBuilder currentEntryBuilder;
 
-        public ParquetStructConverter(Type prestoType, String columnName, GroupType entryType, int fieldIndex)
+        private int[] converterIndexes;
+        private List<Type> outOfOrderFieldTypes;
+        private InterleavedBlockBuilder outOfOrderBlockBuilder; // a tmp builder for fields out of order
+
+        private List<IndexedBlockConverter> createConverters(String columnName, List<Type> prestoTypeParameters, List<parquet.schema.Type> fieldTypes, TypeManager typeManager)
+        {
+            ImmutableList.Builder<IndexedBlockConverter> converters = ImmutableList.builder();
+            for (int i = 0, n = prestoTypeParameters.size(); i < n; i++) {
+                parquet.schema.Type fieldType = fieldTypes.get(i);
+                converters.add(createConverter(prestoTypeParameters.get(i), columnName + "." + fieldType.getName(), fieldType, i, false, typeManager));
+            }
+            return converters.build();
+        }
+
+        private List<IndexedBlockConverter> createConvertersByName(String columnName, Type prestoType, List<parquet.schema.Type> fieldTypes, TypeManager typeManager)
+        {
+            int parquetFieldCount = fieldTypes.size();
+            int prestoFieldCount = prestoType.getTypeSignature().getParameters().size();
+
+            Map<String, FieldInformation> fieldTypeMap = new HashMap<>(prestoFieldCount);
+            for (int i = 0; i < prestoFieldCount; i++) {
+                NamedTypeSignature namedTypeSignature = prestoType.getTypeSignature().getParameters().get(i).getNamedTypeSignature();
+                fieldTypeMap.put(namedTypeSignature.getName().toLowerCase(), FieldInformation.of(i, typeManager.getType(namedTypeSignature.getTypeSignature())));
+            }
+
+            boolean outOfOrder = false;
+            ImmutableList.Builder<IndexedBlockConverter> builder = ImmutableList.builder();
+            for (int i = 0, prevFieldIndex = -1; i < parquetFieldCount; i++) {
+                parquet.schema.Type fieldType = fieldTypes.get(i);
+                FieldInformation fieldInformation = fieldTypeMap.get(fieldType.getName().toLowerCase());
+                if (fieldInformation == null) {
+                    builder.add(fieldType.isPrimitive() ? ParquetDummyPrimitiveConverter.converter : new ParquetDummyGroupConverter(fieldType));
+                }
+                else {
+                    if (prevFieldIndex > fieldInformation.getIndex()) {
+                        outOfOrder = true;
+                    }
+                    builder.add(createConverter(fieldInformation.getType(), columnName + "." + fieldType.getName(), fieldType, fieldInformation.getIndex(), true, typeManager));
+                    prevFieldIndex = fieldInformation.getIndex();
+                }
+            }
+            // When reading parquet files, we need to pass converters and parquet types in parquet schema fields order.
+            // After getting the parquet values, we need to build presto blocks in metastore schema fields order.
+            List<IndexedBlockConverter> converters = builder.build();
+            if (outOfOrder) {
+                ImmutableList.Builder<Type> types = ImmutableList.builder();
+                converterIndexes = new int[parquetFieldCount];
+                for (int i = 0, tmpIndex = 0; i < parquetFieldCount; i++) {
+                    IndexedBlockConverter converter = converters.get(i);
+                    converterIndexes[i] = converter.getFieldIndex();
+                    if (converterIndexes[i] < 0) {
+                        continue;
+                    }
+                    converter.setFieldIndex(tmpIndex++);
+                    types.add(converter.getType());
+                }
+                outOfOrderFieldTypes = types.build();
+            }
+            return converters;
+        }
+
+        public ParquetStructConverter(Type prestoType, String columnName, GroupType entryType, int fieldIndex, boolean useNames, TypeManager typeManager)
         {
             checkArgument(ROW.equals(prestoType.getTypeSignature().getBase()));
-            List<Type> prestoTypeParameters = prestoType.getTypeParameters();
             List<parquet.schema.Type> fieldTypes = entryType.getFields();
-            checkArgument(
-                    prestoTypeParameters.size() == fieldTypes.size(),
-                    "Schema mismatch, metastore schema for row column %s has %s fields but parquet schema has %s fields",
-                    columnName,
-                    prestoTypeParameters.size(),
-                    fieldTypes.size());
+
+            if (useNames || fieldTypes.size() != prestoType.getTypeSignature().getParameters().size()) {
+                this.converters = createConvertersByName(columnName, prestoType, fieldTypes, typeManager);
+            }
+            else {
+                this.converters = createConverters(columnName, prestoType.getTypeParameters(), fieldTypes, typeManager);
+            }
 
             this.rowType = prestoType;
             this.fieldIndex = fieldIndex;
+        }
 
-            ImmutableList.Builder<BlockConverter> converters = ImmutableList.builder();
-            for (int i = 0; i < prestoTypeParameters.size(); i++) {
-                parquet.schema.Type fieldType = fieldTypes.get(i);
-                converters.add(createConverter(prestoTypeParameters.get(i), columnName + "." + fieldType.getName(), fieldType, i));
-            }
-            this.converters = converters.build();
+        @Override
+        public Type getType()
+        {
+            return rowType;
+        }
+
+        @Override
+        public void setFieldIndex(int fieldIndex)
+        {
+            this.fieldIndex = fieldIndex;
+        }
+
+        @Override
+        public int getFieldIndex()
+        {
+            return fieldIndex;
         }
 
         @Override
@@ -771,6 +881,9 @@ public class ParquetHiveRecordCursor
         public void beforeValue(BlockBuilder builder)
         {
             this.builder = builder;
+            if (outOfOrderFieldTypes != null) {
+                outOfOrderBlockBuilder = new InterleavedBlockBuilder(outOfOrderFieldTypes, new BlockBuilderStatus(), NULL_BUILDER_POSITIONS_THRESHOLD);
+            }
         }
 
         @Override
@@ -780,15 +893,23 @@ public class ParquetHiveRecordCursor
                 if (nullBuilder == null || (nullBuilder.getPositionCount() >= NULL_BUILDER_POSITIONS_THRESHOLD && nullBuilder.getSizeInBytes() >= NULL_BUILDER_SIZE_IN_BYTES_THRESHOLD)) {
                     nullBuilder = rowType.createBlockBuilder(new BlockBuilderStatus(), NULL_BUILDER_POSITIONS_THRESHOLD);
                 }
-                currentEntryBuilder = nullBuilder.beginBlockEntry();
+                currentEntryBuilder = nullBuilder;
             }
             else {
                 while (builder.getPositionCount() < fieldIndex) {
                     builder.appendNull();
                 }
-                currentEntryBuilder = builder.beginBlockEntry();
+                currentEntryBuilder = builder;
             }
-            for (BlockConverter converter : converters) {
+
+            if (outOfOrderBlockBuilder != null) {
+                currentEntryBuilder = outOfOrderBlockBuilder;
+            }
+            else {
+                currentEntryBuilder = currentEntryBuilder.beginBlockEntry();
+            }
+
+            for (IndexedBlockConverter converter : converters) {
                 converter.beforeValue(currentEntryBuilder);
             }
         }
@@ -799,7 +920,32 @@ public class ParquetHiveRecordCursor
             for (BlockConverter converter : converters) {
                 converter.afterValue();
             }
-            while (currentEntryBuilder.getPositionCount() < converters.size()) {
+            if (outOfOrderBlockBuilder != null) {
+                if (builder == null) {
+                    currentEntryBuilder = nullBuilder;
+                }
+                else {
+                    currentEntryBuilder = builder;
+                }
+
+                currentEntryBuilder = currentEntryBuilder.beginBlockEntry();
+                List<IndexedBlockConverter> indexedConverters = new ArrayList<>(converters);
+                indexedConverters.sort((IndexedBlockConverter converter1, IndexedBlockConverter converter2)->Integer.compare(converterIndexes[converter1.getFieldIndex()], converterIndexes[converter2.getFieldIndex()]));
+                int positionCount = outOfOrderBlockBuilder.getPositionCount();
+                for (int i = 0; i < converterIndexes.length; i++) {
+                    int position = indexedConverters.get(i).getFieldIndex();
+                    if (converterIndexes[position] < 0 || position >= positionCount) {
+                        continue;
+                    }
+                    while (currentEntryBuilder.getPositionCount() < converterIndexes[position]) {
+                        currentEntryBuilder.appendNull();
+                    }
+                    outOfOrderBlockBuilder.writePositionTo(position, currentEntryBuilder);
+                    currentEntryBuilder.closeEntry();
+                }
+            }
+            int fieldCount = rowType.getTypeParameters().size();
+            while (currentEntryBuilder.getPositionCount() < fieldCount) {
                 currentEntryBuilder.appendNull();
             }
 
@@ -831,14 +977,14 @@ public class ParquetHiveRecordCursor
         private static final int NULL_BUILDER_SIZE_IN_BYTES_THRESHOLD = 32768;
 
         private final Type arrayType;
-        private final int fieldIndex;
+        private int fieldIndex;
 
         private final BlockConverter elementConverter;
         private BlockBuilder builder;
         private BlockBuilder nullBuilder; // used internally when builder is set to null
         private BlockBuilder currentEntryBuilder;
 
-        public ParquetListConverter(Type prestoType, String columnName, GroupType listType, int fieldIndex)
+        public ParquetListConverter(Type prestoType, String columnName, GroupType listType, int fieldIndex, boolean useNames, TypeManager typeManager)
         {
             checkArgument(
                     listType.getFieldCount() == 1,
@@ -864,10 +1010,10 @@ public class ParquetHiveRecordCursor
             // documentation at http://git.io/vOpNz.
             parquet.schema.Type elementType = listType.getType(0);
             if (isElementType(elementType, listType.getName())) {
-                elementConverter = createConverter(prestoType.getTypeParameters().get(0), columnName + ".element", elementType, 0);
+                elementConverter = createConverter(prestoType.getTypeParameters().get(0), columnName + ".element", elementType, 0, useNames, typeManager);
             }
             else {
-                elementConverter = new ParquetListEntryConverter(prestoType.getTypeParameters().get(0), columnName, elementType.asGroupType());
+                elementConverter = new ParquetListEntryConverter(prestoType.getTypeParameters().get(0), columnName, elementType.asGroupType(), useNames, typeManager);
             }
         }
 
@@ -891,6 +1037,24 @@ public class ParquetHiveRecordCursor
             // * name is "bag", which indicates existing hive or pig data
             // * ambiguous case, which should be assumed is 3-level according to spec
             return false;
+        }
+
+        @Override
+        public Type getType()
+        {
+            return arrayType;
+        }
+
+        @Override
+        public void setFieldIndex(int fieldIndex)
+        {
+            this.fieldIndex = fieldIndex;
+        }
+
+        @Override
+        public int getFieldIndex()
+        {
+            return fieldIndex;
         }
 
         @Override
@@ -961,7 +1125,7 @@ public class ParquetHiveRecordCursor
         private BlockBuilder builder;
         private int startingPosition;
 
-        public ParquetListEntryConverter(Type prestoType, String columnName, GroupType elementType)
+        public ParquetListEntryConverter(Type prestoType, String columnName, GroupType elementType, boolean useNames, TypeManager typeManager)
         {
             checkArgument(
                     elementType.getOriginalType() == null,
@@ -975,7 +1139,7 @@ public class ParquetHiveRecordCursor
                     columnName,
                     elementType.getFieldCount());
 
-            elementConverter = createConverter(prestoType, columnName + ".element", elementType.getType(0), 0);
+            elementConverter = createConverter(prestoType, columnName + ".element", elementType.getType(0), 0, useNames, typeManager);
         }
 
         @Override
@@ -1023,14 +1187,14 @@ public class ParquetHiveRecordCursor
         private static final int NULL_BUILDER_SIZE_IN_BYTES_THRESHOLD = 32768;
 
         private final Type mapType;
-        private final int fieldIndex;
+        private int fieldIndex;
 
         private final ParquetMapEntryConverter entryConverter;
         private BlockBuilder builder;
         private BlockBuilder nullBuilder; // used internally when builder is set to null
         private BlockBuilder currentEntryBuilder;
 
-        public ParquetMapConverter(Type type, String columnName, GroupType mapType, int fieldIndex)
+        public ParquetMapConverter(Type type, String columnName, GroupType mapType, int fieldIndex, boolean useNames, TypeManager typeManager)
         {
             checkArgument(
                     mapType.getFieldCount() == 1,
@@ -1043,7 +1207,25 @@ public class ParquetHiveRecordCursor
 
             parquet.schema.Type entryType = mapType.getFields().get(0);
 
-            entryConverter = new ParquetMapEntryConverter(type, columnName + ".entry", entryType.asGroupType());
+            entryConverter = new ParquetMapEntryConverter(type, columnName + ".entry", entryType.asGroupType(), useNames, typeManager);
+        }
+
+        @Override
+        public Type getType()
+        {
+            return mapType;
+        }
+
+        @Override
+        public void setFieldIndex(int fieldIndex)
+        {
+            this.fieldIndex = fieldIndex;
+        }
+
+        @Override
+        public int getFieldIndex()
+        {
+            return fieldIndex;
         }
 
         @Override
@@ -1114,7 +1296,7 @@ public class ParquetHiveRecordCursor
 
         private BlockBuilder builder;
 
-        public ParquetMapEntryConverter(Type prestoType, String columnName, GroupType entryType)
+        public ParquetMapEntryConverter(Type prestoType, String columnName, GroupType entryType, boolean useNames, TypeManager typeManager)
         {
             checkArgument(MAP.equals(prestoType.getTypeSignature().getBase()));
             // original version of parquet used null for entry due to a bug
@@ -1149,8 +1331,8 @@ public class ParquetHiveRecordCursor
                     columnName,
                     entryGroupType.getType(0));
 
-            keyConverter = createConverter(prestoType.getTypeParameters().get(0), columnName + ".key", entryGroupType.getFields().get(0), 0);
-            valueConverter = createConverter(prestoType.getTypeParameters().get(1), columnName + ".value", entryGroupType.getFields().get(1), 1);
+            keyConverter = createConverter(prestoType.getTypeParameters().get(0), columnName + ".key", entryGroupType.getFields().get(0), 0, useNames, typeManager);
+            valueConverter = createConverter(prestoType.getTypeParameters().get(1), columnName + ".value", entryGroupType.getFields().get(1), 1, useNames, typeManager);
         }
 
         @Override
@@ -1198,16 +1380,34 @@ public class ParquetHiveRecordCursor
 
     private static class ParquetPrimitiveConverter
             extends PrimitiveConverter
-            implements BlockConverter
+            implements IndexedBlockConverter
     {
         private final Type type;
-        private final int fieldIndex;
+        private int fieldIndex;
         private BlockBuilder builder;
 
         public ParquetPrimitiveConverter(Type type, int fieldIndex)
         {
             this.type = type;
             this.fieldIndex = fieldIndex;
+        }
+
+        @Override
+        public Type getType()
+        {
+            return type;
+        }
+
+        @Override
+        public void setFieldIndex(int fieldIndex)
+        {
+            this.fieldIndex = fieldIndex;
+        }
+
+        @Override
+        public int getFieldIndex()
+        {
+            return fieldIndex;
         }
 
         @Override
@@ -1312,15 +1512,35 @@ public class ParquetHiveRecordCursor
 
     private static class ParquetDecimalConverter
             extends PrimitiveConverter
-            implements BlockConverter
+            implements IndexedBlockConverter
     {
         private final DecimalType decimalType;
+        private int fieldIndex;
         private BlockBuilder builder;
         private boolean wroteValue;
 
-        public ParquetDecimalConverter(DecimalType decimalType)
+        public ParquetDecimalConverter(DecimalType decimalType, int fieldIndex)
         {
             this.decimalType = requireNonNull(decimalType, "decimalType is null");
+            this.fieldIndex = fieldIndex;
+        }
+
+        @Override
+        public Type getType()
+        {
+            return decimalType;
+        }
+
+        @Override
+        public void setFieldIndex(int fieldIndex)
+        {
+            this.fieldIndex = fieldIndex;
+        }
+
+        @Override
+        public int getFieldIndex()
+        {
+            return fieldIndex;
         }
 
         @Override
@@ -1369,6 +1589,158 @@ public class ParquetHiveRecordCursor
                 decimalType.writeSlice(builder, Decimals.encodeUnscaledValue(unboundedDecimal));
             }
             wroteValue = true;
+        }
+    }
+
+    private static class ParquetDummyPrimitiveConverter
+        extends PrimitiveConverter
+        implements IndexedBlockConverter
+    {
+        static ParquetDummyPrimitiveConverter converter = new ParquetDummyPrimitiveConverter();
+
+        @Override
+        public Type getType()
+        {
+            return null;
+        }
+
+        @Override
+        public void setFieldIndex(int fieldIndex)
+        {
+        }
+
+        @Override
+        public int getFieldIndex()
+        {
+            return -1;
+        }
+
+        @Override
+        public void beforeValue(BlockBuilder builder)
+        {
+        }
+
+        @Override
+        public void afterValue()
+        {
+        }
+
+        @Override
+        public boolean isPrimitive()
+        {
+            return true;
+        }
+
+        @Override
+        public PrimitiveConverter asPrimitiveConverter()
+        {
+            return this;
+        }
+
+        @Override
+        public boolean hasDictionarySupport()
+        {
+            return false;
+        }
+
+        @Override
+        public void setDictionary(Dictionary dictionary)
+        {
+        }
+
+        @Override
+        public void addValueFromDictionary(int dictionaryId)
+        {
+        }
+
+        @Override
+        public void addBoolean(boolean value)
+        {
+        }
+
+        @Override
+        public void addDouble(double value)
+        {
+        }
+
+        @Override
+        public void addLong(long value)
+        {
+        }
+
+        @Override
+        public void addBinary(Binary value)
+        {
+        }
+
+        @Override
+        public void addFloat(float value)
+        {
+        }
+
+        @Override
+        public void addInt(int value)
+        {
+        }
+    }
+
+    private static class ParquetDummyGroupConverter
+        extends GroupConverter
+        implements IndexedBlockConverter
+    {
+        private final List<Converter> converters;
+
+        public ParquetDummyGroupConverter(parquet.schema.Type fieldType)
+        {
+            requireNonNull(fieldType, "fieldType is null");
+            ImmutableList.Builder<Converter> builder = ImmutableList.builder();
+            for (parquet.schema.Type type : fieldType.asGroupType().getFields()) {
+                builder.add(type.isPrimitive() ? ParquetDummyPrimitiveConverter.converter : new ParquetDummyGroupConverter(type));
+            }
+            converters = builder.build();
+        }
+
+        @Override
+        public void beforeValue(BlockBuilder builder)
+        {
+        }
+
+        @Override
+        public void afterValue()
+        {
+        }
+
+        @Override
+        public void setFieldIndex(int fieldIndex)
+        {
+        }
+
+        @Override
+        public int getFieldIndex()
+        {
+            return -1;
+        }
+
+        @Override
+        public Type getType()
+        {
+            return null;
+        }
+
+        @Override
+        public void end()
+        {
+        }
+
+        @Override
+        public Converter getConverter(int fieldIndex)
+        {
+            return converters.get(fieldIndex);
+        }
+
+        @Override
+        public void start()
+        {
         }
     }
 }

--- a/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveClient.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveClient.java
@@ -74,6 +74,7 @@ import com.facebook.presto.testing.MaterializedRow;
 import com.facebook.presto.testing.TestingConnectorSession;
 import com.facebook.presto.type.ArrayType;
 import com.facebook.presto.type.MapType;
+import com.facebook.presto.type.RowType;
 import com.facebook.presto.type.TypeRegistry;
 import com.facebook.presto.util.ImmutableCollectors;
 import com.google.common.collect.ImmutableList;
@@ -514,6 +515,7 @@ public abstract class AbstractTestHiveClient
         if (proxy != null) {
             hiveClientConfig.setMetastoreSocksProxy(HostAndPort.fromString(proxy));
         }
+        hiveClientConfig.setUseParquetColumnNames(true);
 
         HiveCluster hiveCluster = new TestingHiveCluster(hiveClientConfig, host, port);
         metastoreClient = new CachingHiveMetastore(new BridgingHiveMetastore(new ThriftHiveMetastore(hiveCluster)), executor, Duration.valueOf("1m"), Duration.valueOf("15s"));
@@ -2723,6 +2725,22 @@ public abstract class AbstractTestHiveClient
                     }
                 }
 
+                // STRUCT<s_string: STRING, s_double:DOUBLE>
+                index = columnIndex.get("t_struct");
+                if (index != null) {
+                    if ((rowNumber % 31) == 0) {
+                        assertNull(row.getField(index));
+                    }
+                    else {
+                        assertTrue(row.getField(index) instanceof List);
+                        List values = (List) row.getField(index);
+                        assertEquals(values.size(), 3);
+                        assertEquals(values.get(0), "test abc");
+                        assertEquals(values.get(1), 0.1);
+                        assertNull(values.get(2));
+                    }
+                }
+
                 // MAP<INT, ARRAY<STRUCT<s_string: STRING, s_double:DOUBLE>>>
                 index = columnIndex.get("t_complex");
                 if (index != null) {
@@ -2956,7 +2974,7 @@ public abstract class AbstractTestHiveClient
                 else if (DATE.equals(column.getType())) {
                     assertInstanceOf(value, SqlDate.class);
                 }
-                else if (column.getType() instanceof ArrayType) {
+                else if (column.getType() instanceof ArrayType || column.getType() instanceof RowType) {
                     assertInstanceOf(value, List.class);
                 }
                 else if (column.getType() instanceof MapType) {

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveFileFormats.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveFileFormats.java
@@ -23,7 +23,9 @@ import com.facebook.presto.spi.ConnectorSession;
 import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.RecordCursor;
 import com.facebook.presto.spi.RecordPageSource;
+import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.predicate.TupleDomain;
+import com.facebook.presto.spi.type.Type;
 import com.facebook.presto.testing.TestingConnectorSession;
 import com.facebook.presto.type.ArrayType;
 import com.facebook.presto.type.RowType;
@@ -32,6 +34,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
+
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hive.common.type.HiveVarchar;
@@ -45,6 +48,7 @@ import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector;
 import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector.Category;
 import org.apache.hadoop.hive.serde2.objectinspector.PrimitiveObjectInspector;
 import org.apache.hadoop.hive.serde2.objectinspector.PrimitiveObjectInspector.PrimitiveCategory;
+import org.apache.hadoop.hive.serde2.objectinspector.StandardStructObjectInspector;
 import org.apache.hadoop.hive.serde2.objectinspector.StructField;
 import org.apache.hadoop.hive.serde2.objectinspector.StructObjectInspector;
 import org.apache.hadoop.hive.serde2.typeinfo.VarcharTypeInfo;
@@ -99,6 +103,7 @@ import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
 
+@SuppressWarnings({"deprecation", "unused"})
 public class TestHiveFileFormats
         extends AbstractTestHiveFileFormats
 {
@@ -365,54 +370,247 @@ public class TestHiveFileFormats
                 .collect(toList());
     }
 
-    @Test(dataProvider = "rowCount")
-    public void testParquetThrift(int rowCount)
+    @Test
+    public void testParquetExtraStructFields1()
             throws Exception
     {
-        RowType nameType = new RowType(ImmutableList.of(createUnboundedVarcharType(), createUnboundedVarcharType()), Optional.empty());
-        RowType phoneType = new RowType(ImmutableList.of(createUnboundedVarcharType(), createUnboundedVarcharType()), Optional.empty());
+        List<Type> nameTypes = ImmutableList.of(createUnboundedVarcharType(), createUnboundedVarcharType(), createUnboundedVarcharType());
+        RowType nameType = new RowType(nameTypes, Optional.empty());
+        Block expectedNameBlock = rowBlockOf(nameTypes, "Bob", "Roberts", null);
+        StandardStructObjectInspector nameObjectInspector = getStandardStructObjectInspector(
+                ImmutableList.of("first_name", "last_name", "suffix"),
+                ImmutableList.of(javaStringObjectInspector, javaStringObjectInspector, javaStringObjectInspector)
+              );
+
+        StandardStructObjectInspector phoneObjectInspector = getStandardStructObjectInspector(
+                ImmutableList.of("number", "type", "fake_name_struct"),
+                ImmutableList.of(javaStringObjectInspector, javaStringObjectInspector, nameObjectInspector)
+              );
+        Block expectedPhoneBlock = rowBlockOf(ImmutableList.of(createUnboundedVarcharType(), createUnboundedVarcharType(), nameType), "1234567890", null, null);
+
+        testParquetReadAndVerify(nameType,
+                new RowType(ImmutableList.of(createUnboundedVarcharType(), createUnboundedVarcharType(), nameType), Optional.empty()),
+                nameObjectInspector,
+                phoneObjectInspector,
+                expectedNameBlock,
+                expectedPhoneBlock,
+                true);
+    }
+
+    @Test
+    public void testParquetExtraStructFields2()
+            throws Exception
+    {
+        List<Type> nameTypes = ImmutableList.of(createUnboundedVarcharType(), createUnboundedVarcharType(), createUnboundedVarcharType(), createUnboundedVarcharType());
+        RowType nameType = new RowType(nameTypes, Optional.empty());
+        Block expectedNameBlock = rowBlockOf(nameTypes, "Bob", null, "Roberts", null);
+        StandardStructObjectInspector nameObjectInspector = getStandardStructObjectInspector(
+                ImmutableList.of("first_name", "middle", "last_name", "suffix"),
+                ImmutableList.of(javaStringObjectInspector, javaStringObjectInspector, javaStringObjectInspector, javaStringObjectInspector)
+              );
+
+        StandardStructObjectInspector phoneObjectInspector = getStandardStructObjectInspector(
+                ImmutableList.of("fake_name_struct", "number", "type"),
+                ImmutableList.of(nameObjectInspector, javaStringObjectInspector, javaStringObjectInspector)
+              );
+        Block expectedPhoneBlock = rowBlockOf(ImmutableList.of(nameType, createUnboundedVarcharType(), createUnboundedVarcharType()), null, "1234567890", null);
+
+        testParquetReadAndVerify(nameType,
+                new RowType(ImmutableList.of(nameType, createUnboundedVarcharType(), createUnboundedVarcharType()), Optional.empty()),
+                nameObjectInspector,
+                phoneObjectInspector,
+                expectedNameBlock,
+                expectedPhoneBlock,
+                true);
+    }
+
+    @Test
+    public void testParquetRemovedStructFields1()
+            throws Exception
+    {
+        List<Type> nameTypes = ImmutableList.of(createUnboundedVarcharType(), createUnboundedVarcharType());
+        RowType nameType = new RowType(nameTypes, Optional.empty());
+        Block expectedNameBlock = rowBlockOf(nameTypes, "Bob", null);
+        StandardStructObjectInspector nameObjectInspector = getStandardStructObjectInspector(
+                ImmutableList.of("first_name", "middle"),
+                ImmutableList.of(javaStringObjectInspector, javaStringObjectInspector)
+              );
+
+        StandardStructObjectInspector phoneObjectInspector = getStandardStructObjectInspector(
+                ImmutableList.of("number"),
+                ImmutableList.of(javaStringObjectInspector)
+              );
+        Block expectedPhoneBlock = rowBlockOf(ImmutableList.of(createUnboundedVarcharType()), "1234567890");
+
+        testParquetReadAndVerify(nameType,
+                new RowType(ImmutableList.of(createUnboundedVarcharType()), Optional.empty()),
+                nameObjectInspector,
+                phoneObjectInspector,
+                expectedNameBlock,
+                expectedPhoneBlock,
+                true);
+    }
+
+    @Test
+    public void testParquetRemovedStructFields2()
+            throws Exception
+    {
+        List<Type> nameTypes = ImmutableList.of(createUnboundedVarcharType());
+        RowType nameType = new RowType(nameTypes, Optional.empty());
+        Block expectedNameBlock = rowBlockOf(nameTypes, "Roberts");
+        StandardStructObjectInspector nameObjectInspector = getStandardStructObjectInspector(
+                ImmutableList.of("last_name"),
+                ImmutableList.of(javaStringObjectInspector)
+              );
+
+        StandardStructObjectInspector phoneObjectInspector = getStandardStructObjectInspector(
+                ImmutableList.of("fake_name_struct", "number"),
+                ImmutableList.of(nameObjectInspector, javaStringObjectInspector)
+              );
+        Block expectedPhoneBlock = rowBlockOf(ImmutableList.of(nameType, createUnboundedVarcharType()), null, "1234567890");
+
+        testParquetReadAndVerify(nameType,
+                new RowType(ImmutableList.of(nameType, createUnboundedVarcharType()), Optional.empty()),
+                nameObjectInspector,
+                phoneObjectInspector,
+                expectedNameBlock,
+                expectedPhoneBlock,
+                true);
+    }
+
+    @Test
+    public void testParquetStructFieldOrderChanged()
+            throws Exception
+    {
+        List<Type> nameTypes = ImmutableList.of(createUnboundedVarcharType(), createUnboundedVarcharType());
+        RowType nameType = new RowType(nameTypes, Optional.empty());
+        Block expectedNameBlock = rowBlockOf(nameTypes, "Roberts", "Bob");
+        StandardStructObjectInspector nameObjectInspector = getStandardStructObjectInspector(
+                ImmutableList.of("last_name", "first_name"),
+                ImmutableList.of(javaStringObjectInspector, javaStringObjectInspector)
+              );
+
+        StandardStructObjectInspector phoneObjectInspector = getStandardStructObjectInspector(
+                ImmutableList.of("type", "number"),
+                ImmutableList.of(javaStringObjectInspector, javaStringObjectInspector)
+              );
+        Block expectedPhoneBlock = rowBlockOf(ImmutableList.of(createUnboundedVarcharType(), createUnboundedVarcharType()), null, "1234567890");
+
+        testParquetReadAndVerify(nameType,
+                new RowType(ImmutableList.of(createUnboundedVarcharType(), createUnboundedVarcharType()), Optional.empty()),
+                nameObjectInspector,
+                phoneObjectInspector,
+                expectedNameBlock,
+                expectedPhoneBlock,
+                true);
+    }
+
+    @Test
+    public void testParquetStructFieldOrderChangedWithExtraFields()
+            throws Exception
+    {
+        List<Type> nameTypes = ImmutableList.of(createUnboundedVarcharType(), createUnboundedVarcharType(), createUnboundedVarcharType(), createUnboundedVarcharType());
+        RowType nameType = new RowType(nameTypes, Optional.empty());
+        Block expectedNameBlock = rowBlockOf(nameTypes, null, "Roberts", null, "Bob");
+        StandardStructObjectInspector nameObjectInspector = getStandardStructObjectInspector(
+                ImmutableList.of("middle", "last_name", "suffix", "first_name"),
+                ImmutableList.of(javaStringObjectInspector, javaStringObjectInspector, javaStringObjectInspector, javaStringObjectInspector)
+              );
+
+        StandardStructObjectInspector phoneObjectInspector = getStandardStructObjectInspector(
+                ImmutableList.of("type", "fake_name_struct", "number"),
+                ImmutableList.of(javaStringObjectInspector, nameObjectInspector, javaStringObjectInspector)
+              );
+        Block expectedPhoneBlock = rowBlockOf(ImmutableList.of(createUnboundedVarcharType(), nameType, createUnboundedVarcharType()), null, null, "1234567890");
+
+        testParquetReadAndVerify(nameType,
+                new RowType(ImmutableList.of(createUnboundedVarcharType(), nameType, createUnboundedVarcharType()), Optional.empty()),
+                nameObjectInspector,
+                phoneObjectInspector,
+                expectedNameBlock,
+                expectedPhoneBlock,
+                true);
+    }
+
+    @Test
+    public void testParquetThriftUseNames()
+            throws Exception
+    {
+        testParquetThrift(true);
+    }
+
+    @Test
+    public void testParquetThriftUseIndexes()
+            throws Exception
+    {
+        testParquetThrift(false);
+    }
+
+    private void testParquetThrift(boolean useParquetColumnNames)
+            throws Exception
+    {
+        List<Type> nameTypes = ImmutableList.of(createUnboundedVarcharType(), createUnboundedVarcharType());
+        Block expectedNameBlock = rowBlockOf(nameTypes, "Bob", "Roberts");
+        StandardStructObjectInspector nameObjectInspector = getStandardStructObjectInspector(
+                ImmutableList.of("first_name", "last_name"),
+                ImmutableList.of(javaStringObjectInspector, javaStringObjectInspector)
+              );
+
+        StandardStructObjectInspector phoneObjectInspector = getStandardStructObjectInspector(
+                ImmutableList.of("number", "type"),
+                ImmutableList.of(javaStringObjectInspector, javaStringObjectInspector)
+              );
+        Block expectedPhoneBlock = rowBlockOf(ImmutableList.of(createUnboundedVarcharType(), createUnboundedVarcharType()), "1234567890", null);
+
+        testParquetReadAndVerify(new RowType(nameTypes, Optional.empty()),
+                new RowType(ImmutableList.of(createUnboundedVarcharType(), createUnboundedVarcharType()), Optional.empty()),
+                nameObjectInspector,
+                phoneObjectInspector,
+                expectedNameBlock,
+                expectedPhoneBlock,
+                useParquetColumnNames);
+    }
+
+    private void testParquetReadAndVerify(RowType nameType,
+            RowType phoneType,
+            StandardStructObjectInspector nameObjectInspector,
+            StandardStructObjectInspector phoneObjectInspector,
+            Block expectedNameBlock,
+            Block expectedPhoneBlock,
+            boolean useParquetColumnNames)
+            throws Exception
+    {
         RowType personType = new RowType(ImmutableList.of(nameType, INTEGER, createUnboundedVarcharType(), new ArrayType(phoneType)), Optional.empty());
 
-        List<TestColumn> testColumns = ImmutableList.of(
+        List<TestColumn> testColumns = ImmutableList.<TestColumn>of(
                 new TestColumn(
                         "persons",
                         getStandardListObjectInspector(
                                 getStandardStructObjectInspector(
                                         ImmutableList.of("name", "id", "email", "phones"),
-                                        ImmutableList.of(
-                                                getStandardStructObjectInspector(
-                                                        ImmutableList.of("first_name", "last_name"),
-                                                        ImmutableList.of(javaStringObjectInspector, javaStringObjectInspector)
-                                                ),
+                                        ImmutableList.<ObjectInspector>of(
+                                                nameObjectInspector,
                                                 javaIntObjectInspector,
                                                 javaStringObjectInspector,
-                                                getStandardListObjectInspector(
-                                                        getStandardStructObjectInspector(
-                                                                ImmutableList.of("number", "type"),
-                                                                ImmutableList.of(javaStringObjectInspector, javaStringObjectInspector)
-                                                        )
-                                                )
+                                                getStandardListObjectInspector(phoneObjectInspector))
                                         )
-                                )
-                        ),
+                                ),
                         null,
                         arrayBlockOf(personType,
                                 rowBlockOf(ImmutableList.of(nameType, INTEGER, createUnboundedVarcharType(), new ArrayType(phoneType)),
-                                        rowBlockOf(ImmutableList.of(createUnboundedVarcharType(), createUnboundedVarcharType()), "Bob", "Roberts"),
+                                        expectedNameBlock,
                                         0,
                                         "bob.roberts@example.com",
-                                        arrayBlockOf(phoneType, rowBlockOf(ImmutableList.of(createUnboundedVarcharType(), createUnboundedVarcharType()), "1234567890", null))
+                                        arrayBlockOf(phoneType, expectedPhoneBlock))
                                 )
                         )
-                )
         );
 
         InputFormat<?, ?> inputFormat = new MapredParquetInputFormat();
-        @SuppressWarnings("deprecation")
         SerDe serde = new ParquetHiveSerDe();
         File file = new File(this.getClass().getClassLoader().getResource("addressbook.parquet").getPath());
         FileSplit split = new FileSplit(new Path(file.getAbsolutePath()), 0, file.length(), new String[0]);
-        HiveRecordCursorProvider cursorProvider = new ParquetRecordCursorProvider(false, HDFS_ENVIRONMENT);
+        HiveRecordCursorProvider cursorProvider = new ParquetRecordCursorProvider(useParquetColumnNames, HDFS_ENVIRONMENT);
         testCursorProvider(cursorProvider, split, inputFormat, serde, testColumns, 1);
     }
 
@@ -547,7 +745,7 @@ public class TestHiveFileFormats
     private void testCursorProvider(HiveRecordCursorProvider cursorProvider,
             FileSplit split,
             InputFormat<?, ?> inputFormat,
-            @SuppressWarnings("deprecation") SerDe serde,
+            SerDe serde,
             List<TestColumn> testColumns,
             int rowCount)
             throws IOException

--- a/presto-hive/src/test/sql/create-test-hive13.sql
+++ b/presto-hive/src/test/sql/create-test-hive13.sql
@@ -82,7 +82,6 @@ SELECT * FROM presto_test_types_textfile
 ;
 
 
--- Parquet fails when trying to use complex nested types.
 -- Parquet is missing TIMESTAMP and BINARY.
 CREATE TABLE presto_test_types_parquet (
   t_string STRING
@@ -99,11 +98,14 @@ CREATE TABLE presto_test_types_parquet (
 , t_map MAP<STRING, STRING>
 , t_array_string ARRAY<STRING>
 , t_array_struct ARRAY<STRUCT<s_string: STRING, s_double:DOUBLE>>
+, t_struct STRUCT<s_string: STRING, s_double:DOUBLE>
 )
+PARTITIONED BY (dummy INT)
 STORED AS PARQUET
 ;
 
 INSERT INTO TABLE presto_test_types_parquet
+PARTITION (dummy=0)
 SELECT
   t_string
 , t_varchar
@@ -119,9 +121,12 @@ SELECT
 , t_map
 , t_array_string
 , t_array_struct
+, t_array_struct[0]
 FROM presto_test_types_textfile
 ;
 
+ALTER TABLE presto_test_types_parquet
+CHANGE COLUMN t_struct t_struct STRUCT<s_string:STRING, s_double:DOUBLE, s_boolean:BOOLEAN>;
 
 ALTER TABLE presto_test_types_textfile ADD COLUMNS (new_column INT);
 ALTER TABLE presto_test_types_sequencefile ADD COLUMNS (new_column INT);


### PR DESCRIPTION
Added a lazy equals function in HiveType which only compare the catalog if the type is not primitive.
Added a configuration option for enabling the lazy schema matcher.
Includes a name based nested field mapping from #4714