### PR TITLE
Put the tmp path under a user's folder

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveWriteUtils.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveWriteUtils.java
@@ -468,7 +468,7 @@ public final class HiveWriteUtils
     public static Path createTemporaryPath(String user, HdfsEnvironment hdfsEnvironment, Path targetPath)
     {
         // use a per-user temporary directory to avoid permission problems
-        String temporaryPrefix = "/user/hive/warehouse/.hive-staging/presto-" + user;
+        String temporaryPrefix = "/user/" + user + "/warehouse/.hive-staging";
 
         // use relative temporary directory on ViewFS
         if (isViewFileSystem(user, hdfsEnvironment, targetPath)) {

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveWriteUtils.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveWriteUtils.java
@@ -468,7 +468,7 @@ public final class HiveWriteUtils
     public static Path createTemporaryPath(String user, HdfsEnvironment hdfsEnvironment, Path targetPath)
     {
         // use a per-user temporary directory to avoid permission problems
-        String temporaryPrefix = "/tmp/presto-" + user;
+        String temporaryPrefix = "/user/hive/warehouse/.hive-staging/presto-" + user;
 
         // use relative temporary directory on ViewFS
         if (isViewFileSystem(user, hdfsEnvironment, targetPath)) {


### PR DESCRIPTION
We can use this workaround to allow user create a table under the "default" schema.