### PR TITLE
Added file path for errors on splitting blocks

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/BackgroundHiveSplitLoader.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/BackgroundHiveSplitLoader.java
@@ -624,7 +624,7 @@ public class BackgroundHiveSplitLoader
                     while (chunkOffset >= blockLocation.getLength()) {
                         // allow overrun for lzo compressed file for intermediate blocks
                         if (!isLzopCompressedFile(filePath) || blockLocation.getOffset() + blockLocation.getLength() >= length) {
-                            checkState(chunkOffset == blockLocation.getLength(), "Error splitting blocks");
+                            checkState(chunkOffset == blockLocation.getLength(), "Error splitting blocks for file: " + filePath.toString() + "");
                         }
                         blockLocationIterator.next();
                         chunkOffset -= blockLocation.getLength();


### PR DESCRIPTION
It appears that some lzo index files might be incorrect/corrupt(index runover file end). To help data vendor to re-index the file/drop the index file, Presto could include the file path in the error message.