### PR TITLE
Unwrap the FileSystemWrapper in isHDFSCompatibleViewFileSystem

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveWriteUtils.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveWriteUtils.java
@@ -448,7 +448,7 @@ public final class HiveWriteUtils
     public static boolean isHDFSCompatibleViewFileSystem(HdfsContext context, HdfsEnvironment hdfsEnvironment, Path path)
     {
         try {
-            return hdfsEnvironment.getFileSystem(context, path)
+            return getRawFileSystem(hdfsEnvironment.getFileSystem(context, path))
                     .getClass().getName().equals("org.apache.hadoop.fs.viewfs.HDFSCompatibleViewFileSystem");
         }
         catch (IOException e) {


### PR DESCRIPTION
A newer version of the shaded Hadoop lib used for Presto is wrapping the raw file system under FileSystemWrapper which caused Presto missed our HDFSCompatibleViewFileSystem check.

`hdfsEnvironment.getFileSystem(context, targetPath).getClass().getName()` is `org.apache.hadoop.fs.PrestoFileSystemCache$FileSystemWrapper`