### PR TITLE
Allow non-secured request authentication over pathes matching given regrex

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/server/security/SecurityConfig.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/security/SecurityConfig.java
@@ -33,6 +33,8 @@ public class SecurityConfig
 
     private Set<AuthenticationType> authenticationTypes = ImmutableSet.of();
 
+    private String httpAuthenticationPathRegex = "^\b$";
+
     public enum AuthenticationType
     {
         CERTIFICATE,
@@ -64,6 +66,20 @@ public class SecurityConfig
         authenticationTypes = stream(SPLITTER.split(types))
                 .map(AuthenticationType::valueOf)
                 .collect(toImmutableSet());
+        return this;
+    }
+
+    @NotNull
+    public String getHttpAuthenticationPathRegex()
+    {
+        return httpAuthenticationPathRegex;
+    }
+
+    @Config("http-server.http.authentication.path.regex")
+    @ConfigDescription("Regex of path that needs to be authenticated for non-secured http request")
+    public SecurityConfig setHttpAuthenticationPathRegex(String regex)
+    {
+        httpAuthenticationPathRegex = regex;
         return this;
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/server/security/ServerSecurityModule.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/security/ServerSecurityModule.java
@@ -38,6 +38,7 @@ public class ServerSecurityModule
     {
         newSetBinder(binder, Filter.class, TheServlet.class).addBinding()
                 .to(AuthenticationFilter.class).in(Scopes.SINGLETON);
+        configBinder(binder).bindConfig(SecurityConfig.class);
 
         Set<AuthenticationType> authTypes = buildConfigObject(SecurityConfig.class).getAuthenticationTypes();
         Multibinder<Authenticator> authBinder = newSetBinder(binder, Authenticator.class);

--- a/presto-main/src/test/java/com/facebook/presto/server/security/TestSecurityConfig.java
+++ b/presto-main/src/test/java/com/facebook/presto/server/security/TestSecurityConfig.java
@@ -29,7 +29,8 @@ public class TestSecurityConfig
     public void testDefaults()
     {
         ConfigAssertions.assertRecordedDefaults(ConfigAssertions.recordDefaults(SecurityConfig.class)
-                .setAuthenticationTypes(""));
+                .setAuthenticationTypes("")
+                .setHttpAuthenticationPathRegex("^\b$"));
     }
 
     @Test
@@ -37,10 +38,12 @@ public class TestSecurityConfig
     {
         Map<String, String> properties = new ImmutableMap.Builder<String, String>()
                 .put("http-server.authentication.type", "KERBEROS,LDAP")
+                .put("http-server.http.authentication.path.regex", "^/v1/statement")
                 .build();
 
         SecurityConfig expected = new SecurityConfig()
-                .setAuthenticationTypes(ImmutableSet.of(KERBEROS, LDAP));
+                .setAuthenticationTypes(ImmutableSet.of(KERBEROS, LDAP))
+                .setHttpAuthenticationPathRegex("^/v1/statement");
 
         ConfigAssertions.assertFullMapping(properties, expected);
     }


### PR DESCRIPTION
This is useful when the non-secured port hosted behind a secured front-end service and direct non-secured port access has been limited by a firewall