### PR TITLE
Allow specifying service principal for Kerberos authenticator

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/server/security/KerberosAuthenticator.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/security/KerberosAuthenticator.java
@@ -64,8 +64,9 @@ public class KerberosAuthenticator
         System.setProperty("java.security.krb5.conf", config.getKerberosConfig().getAbsolutePath());
 
         try {
+            boolean isCompleteServicePrinciple = config.getServiceName().contains("@");
             String hostname = InetAddress.getLocalHost().getCanonicalHostName().toLowerCase(Locale.US);
-            String servicePrincipal = config.getServiceName() + "/" + hostname;
+            String servicePrincipal = isCompleteServicePrinciple ? config.getServiceName() : config.getServiceName() + "/" + hostname;
             loginContext = new LoginContext("", null, null, new Configuration()
             {
                 @Override
@@ -91,7 +92,7 @@ public class KerberosAuthenticator
             loginContext.login();
 
             serverCredential = doAs(loginContext.getSubject(), () -> gssManager.createCredential(
-                    gssManager.createName(config.getServiceName() + "@" + hostname, GSSName.NT_HOSTBASED_SERVICE),
+                    isCompleteServicePrinciple ? gssManager.createName(config.getServiceName(), GSSName.NT_USER_NAME) : gssManager.createName(config.getServiceName() + "@" + hostname, GSSName.NT_HOSTBASED_SERVICE),
                     INDEFINITE_LIFETIME,
                     new Oid[] {
                             new Oid("1.2.840.113554.1.2.2"), // kerberos 5

--- a/presto-product-tests/conf/presto/etc/singlenode-kerberized.properties
+++ b/presto-product-tests/conf/presto/etc/singlenode-kerberized.properties
@@ -18,7 +18,7 @@ discovery.uri=https://presto-master.docker.cluster:7778
 
 http.authentication.krb5.config=/etc/krb5.conf
 http-server.authentication.type=KERBEROS,CERTIFICATE
-http.server.authentication.krb5.service-name=presto-server
+http.server.authentication.krb5.service-name=presto-server/presto-master.docker.cluster@LABS.TERADATA.COM
 http-server.http.enabled=false
 http-server.https.enabled=true
 http-server.https.port=7778

--- a/presto-product-tests/conf/tempto/tempto-configuration-for-docker-kerberos.yaml
+++ b/presto-product-tests/conf/tempto/tempto-configuration-for-docker-kerberos.yaml
@@ -37,7 +37,7 @@ databases:
     cli_kerberos_principal: presto-client/presto-master.docker.cluster@LABS.TERADATA.COM
     cli_kerberos_keytab: /etc/presto/conf/presto-client.keytab
     cli_kerberos_config_path: /etc/krb5.conf
-    cli_kerberos_service_name: presto-server
+    cli_kerberos_service_name: presto-server/presto-master.docker.cluster@LABS.TERADATA.COM
     cli_kerberos_use_canonical_hostname: false
     configured_hdfs_user: hdfs
 


### PR DESCRIPTION
The built-in host-based service name type for Kerberos authenticator cannot fit our use case. By allowing pass a specific service principle and use the user based name type, the authenticator can be authenticated by Kerberos master without specifying the host running Presto service.
This should be a common scenario that the service is running on a managed cloud computing environment.