### PR TITLE
Use HadoopLzoDecompressor in ParquetCompressionUtils

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/parquet/HadoopLzoDecompressor.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/parquet/HadoopLzoDecompressor.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.facebook.presto.hive.parquet;
+
+import com.hadoop.compression.lzo.LzoCodec;
+import io.airlift.compress.Decompressor;
+import io.airlift.compress.MalformedInputException;
+import org.apache.hadoop.conf.Configuration;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+
+// HadoopLzoDecompressor from aircompressor
+public class HadoopLzoDecompressor
+        implements Decompressor
+{
+    private static final Configuration HADOOP_CONF = new Configuration();
+
+    private final org.apache.hadoop.io.compress.Decompressor decompressor;
+
+    public HadoopLzoDecompressor()
+    {
+        LzoCodec codec = new LzoCodec();
+        codec.setConf(HADOOP_CONF);
+        decompressor = codec.createDecompressor();
+    }
+
+    @Override
+    public int decompress(byte[] input, int inputOffset, int inputLength, byte[] output, int outputOffset, int maxOutputLength)
+            throws MalformedInputException
+    {
+        decompressor.setInput(input, inputOffset, inputLength);
+
+        int offset = outputOffset;
+        int outputLimit = outputOffset + maxOutputLength;
+        while (!decompressor.finished() && offset < outputLimit) {
+            try {
+                offset += decompressor.decompress(output, offset, outputLimit - offset);
+            }
+            catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        }
+
+        return offset - outputOffset;
+    }
+
+    @Override
+    public void decompress(ByteBuffer input, ByteBuffer output)
+            throws MalformedInputException
+    {
+        throw new UnsupportedOperationException("Not supported in HadoopLzoDecompressor");
+    }
+}

--- a/presto-hive/src/main/java/com/facebook/presto/hive/parquet/HadoopLzoDecompressor.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/parquet/HadoopLzoDecompressor.java
@@ -22,6 +22,8 @@ import org.apache.hadoop.conf.Configuration;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 
+import static com.google.common.base.Preconditions.checkArgument;
+
 // HadoopLzoDecompressor from aircompressor
 public class HadoopLzoDecompressor
         implements Decompressor
@@ -54,7 +56,7 @@ public class HadoopLzoDecompressor
                 throw new RuntimeException(e);
             }
         }
-
+        checkArgument(decompressor.getRemaining() == 0);
         return offset - outputOffset;
     }
 

--- a/presto-hive/src/main/java/com/facebook/presto/hive/parquet/HadoopLzoDecompressor.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/parquet/HadoopLzoDecompressor.java
@@ -41,6 +41,7 @@ public class HadoopLzoDecompressor
     public int decompress(byte[] input, int inputOffset, int inputLength, byte[] output, int outputOffset, int maxOutputLength)
             throws MalformedInputException
     {
+        decompressor.reset();
         decompressor.setInput(input, inputOffset, inputLength);
 
         int offset = outputOffset;

--- a/presto-hive/src/main/java/com/facebook/presto/hive/parquet/ParquetCompressionUtils.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/parquet/ParquetCompressionUtils.java
@@ -14,7 +14,6 @@
 package com.facebook.presto.hive.parquet;
 
 import io.airlift.compress.Decompressor;
-import io.airlift.compress.lzo.LzoDecompressor;
 import io.airlift.compress.snappy.SnappyDecompressor;
 import io.airlift.slice.DynamicSliceOutput;
 import io.airlift.slice.Slice;
@@ -88,7 +87,7 @@ public final class ParquetCompressionUtils
 
     private static Slice decompressLZO(Slice input, int uncompressedSize)
     {
-        LzoDecompressor lzoDecompressor = new LzoDecompressor();
+        Decompressor lzoDecompressor = new HadoopLzoDecompressor();
         long totalDecompressedCount = 0;
         // over allocate buffer which makes decompression easier
         byte[] output = new byte[uncompressedSize + SIZE_OF_LONG];


### PR DESCRIPTION
Use HadoopLzoDecompressor in ParquetCompressionUtils. The HadoopLzoDecompressor implements the airlift Decompressor interface and replaces the aircompressor LzoDecompressor in decompressLZO function.