### PR TITLE
Fix find field by name in optimized parquet reader

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/parquet/ParquetPageSource.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/parquet/ParquetPageSource.java
@@ -40,8 +40,8 @@ import java.util.Properties;
 import static com.facebook.presto.hive.HiveColumnHandle.ColumnType.REGULAR;
 import static com.facebook.presto.hive.HiveErrorCode.HIVE_BAD_DATA;
 import static com.facebook.presto.hive.HiveErrorCode.HIVE_CURSOR_ERROR;
+import static com.facebook.presto.hive.parquet.ParquetTypeUtils.findFieldIndexByName;
 import static com.facebook.presto.hive.parquet.ParquetTypeUtils.getDescriptor;
-import static com.facebook.presto.hive.parquet.ParquetTypeUtils.getFieldIndex;
 import static com.facebook.presto.hive.parquet.ParquetTypeUtils.getParquetType;
 import static com.facebook.presto.spi.type.StandardTypes.ARRAY;
 import static com.facebook.presto.spi.type.StandardTypes.MAP;
@@ -170,7 +170,7 @@ public class ParquetPageSource
                     Type type = types.get(fieldId);
                     int fieldIndex;
                     if (useParquetColumnNames) {
-                        fieldIndex = getFieldIndex(fileSchema, columnNames.get(fieldId));
+                        fieldIndex = findFieldIndexByName(fileSchema, columnNames.get(fieldId));
                     }
                     else {
                         fieldIndex = hiveColumnIndexes[fieldId];

--- a/presto-hive/src/main/java/com/facebook/presto/hive/parquet/ParquetTypeUtils.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/parquet/ParquetTypeUtils.java
@@ -169,6 +169,35 @@ public final class ParquetTypeUtils
         return type;
     }
 
+    // Find the column index by name following the same logic as findParquetTypeByName
+    public static int findFieldIndexByName(MessageType fileSchema, String name)
+    {
+        try {
+            return fileSchema.getFieldIndex(name);
+        }
+        catch (InvalidRecordException e) {
+            for (parquet.schema.Type type : fileSchema.getFields()) {
+                if (type.getName().equalsIgnoreCase(name)) {
+                    return fileSchema.getFieldIndex(type.getName());
+                }
+            }
+
+            // when a parquet field is a hive keyword we append an _ to it in hive. When doing
+            // a name-based lookup, we need to strip it off again if we didn't get a direct match.
+            if (name.endsWith("_")) {
+                String alternativeName = name.substring(0, name.length() - 1);
+                for (parquet.schema.Type type : fileSchema.getFields()) {
+                    if (type.getName().equalsIgnoreCase(alternativeName)) {
+                        return fileSchema.getFieldIndex(type.getName());
+                    }
+                }
+            }
+
+            // file not found
+            return -1;
+        }
+    }
+
     public static ParquetEncoding getParquetEncoding(Encoding encoding)
     {
         switch (encoding) {


### PR DESCRIPTION
Fix the issue where optimized parquet reader can't find field when the filed name differs from that in parquet file metadata.