### PR TITLE
Fix type mismatch in parquet predicate pushdown

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/parquet/ParquetTypeUtils.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/parquet/ParquetTypeUtils.java
@@ -77,7 +77,7 @@ public final class ParquetTypeUtils
         int index = -1;
         for (int columnIndex = 0; columnIndex < columns.size(); columnIndex++) {
             ColumnIO[] fields = columns.get(columnIndex).getPath();
-            if (fields.length <= maxLevel) {
+            if (fields.length != maxLevel + 1) {
                 continue;
             }
             if (fields[maxLevel].getName().equalsIgnoreCase(path.get(maxLevel - 1))) {

--- a/presto-hive/src/main/java/com/facebook/presto/hive/parquet/predicate/ParquetPredicateUtils.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/parquet/predicate/ParquetPredicateUtils.java
@@ -49,6 +49,7 @@ import java.util.Set;
 import static com.facebook.presto.hive.parquet.ParquetCompressionUtils.decompress;
 import static com.facebook.presto.hive.parquet.ParquetTypeUtils.getDescriptor;
 import static com.facebook.presto.hive.parquet.ParquetTypeUtils.getParquetEncoding;
+import static com.facebook.presto.hive.parquet.ParquetTypeUtils.getStrictDescriptor;
 import static com.facebook.presto.spi.type.IntegerType.INTEGER;
 import static com.facebook.presto.spi.type.SmallintType.SMALLINT;
 import static com.facebook.presto.spi.type.TinyintType.TINYINT;
@@ -83,7 +84,7 @@ public final class ParquetPredicateUtils
 
         ImmutableMap.Builder<ColumnDescriptor, Domain> predicate = ImmutableMap.builder();
         for (Entry<HiveColumnHandle, Domain> entry : effectivePredicate.getDomains().get().entrySet()) {
-            Optional<RichColumnDescriptor> descriptor = getDescriptor(fileSchema, requestedSchema, ImmutableList.of(entry.getKey().getName()));
+            Optional<RichColumnDescriptor> descriptor = getStrictDescriptor(fileSchema, requestedSchema, ImmutableList.of(entry.getKey().getName()));
             if (descriptor.isPresent()) {
                 predicate.put(descriptor.get(), entry.getValue());
             }

--- a/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveFileFormats.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveFileFormats.java
@@ -23,6 +23,8 @@ import com.facebook.presto.spi.RecordCursor;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
 import com.facebook.presto.spi.block.BlockBuilderStatus;
+import com.facebook.presto.spi.predicate.Domain;
+import com.facebook.presto.spi.predicate.TupleDomain;
 import com.facebook.presto.spi.type.ArrayType;
 import com.facebook.presto.spi.type.CharType;
 import com.facebook.presto.spi.type.DateType;
@@ -484,6 +486,13 @@ public abstract class AbstractTestHiveFileFormats
             columns.add(new HiveColumnHandle(testColumn.getName(), hiveType, hiveType.getTypeSignature(), columnIndex, testColumn.isPartitionKey() ? PARTITION_KEY : REGULAR, Optional.empty()));
         }
         return columns;
+    }
+
+    protected TupleDomain<HiveColumnHandle> createEffectivePredicate(List<TestColumn> predicateColumns)
+    {
+        ImmutableMap<HiveColumnHandle, Domain> domains = getColumnHandles(predicateColumns).stream()
+                .collect(ImmutableMap.toImmutableMap(column -> column, column -> Domain.notNull(column.getHiveType().getType(TYPE_MANAGER))));
+        return TupleDomain.withColumnDomains(domains);
     }
 
     public static FileSplit createTestFile(

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveFileFormats.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveFileFormats.java
@@ -24,7 +24,6 @@ import com.facebook.presto.spi.ConnectorSession;
 import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.RecordCursor;
 import com.facebook.presto.spi.RecordPageSource;
-import com.facebook.presto.spi.predicate.TupleDomain;
 import com.facebook.presto.spi.type.ArrayType;
 import com.facebook.presto.spi.type.RowType;
 import com.facebook.presto.testing.TestingConnectorSession;
@@ -496,7 +495,7 @@ public class TestHiveFileFormats
         File file = new File(this.getClass().getClassLoader().getResource("addressbook.parquet").getPath());
         FileSplit split = new FileSplit(new Path(file.getAbsolutePath()), 0, file.length(), new String[0]);
         HiveRecordCursorProvider cursorProvider = new ParquetRecordCursorProvider(false, HDFS_ENVIRONMENT);
-        testCursorProvider(cursorProvider, split, PARQUET, testColumns, 1);
+        testCursorProvider(cursorProvider, split, PARQUET, testColumns, SESSION, 1);
     }
 
     @Test(dataProvider = "rowCount")
@@ -534,7 +533,7 @@ public class TestHiveFileFormats
         File file = new File(this.getClass().getClassLoader().getResource("addressbook.thrift.lzo").getPath());
         FileSplit split = new FileSplit(new Path(file.getAbsolutePath()), 0, file.length(), new String[0]);
         HiveRecordCursorProvider cursorProvider = new ThriftHiveRecordCursorProvider(HDFS_ENVIRONMENT, new HiveThriftFieldIdResolverFactory());
-        testCursorProvider(cursorProvider, split, THRIFTBINARY, testColumns, 1);
+        testCursorProvider(cursorProvider, split, THRIFTBINARY, testColumns, SESSION, 1);
     }
 
     @Test(dataProvider = "rowCount")
@@ -692,6 +691,7 @@ public class TestHiveFileFormats
             FileSplit split,
             HiveStorageFormat storageFormat,
             List<TestColumn> testColumns,
+            ConnectorSession session,
             int rowCount)
             throws IOException
     {
@@ -713,18 +713,21 @@ public class TestHiveFileFormats
         if (storageFormat.equals(THRIFTBINARY)) {
             configuration.set("io.compression.codecs", "com.hadoop.compression.lzo.LzoCodec,com.hadoop.compression.lzo.LzopCodec");
         }
+        List<TestColumn> predicateColumns = TEST_COLUMNS.stream()
+                .filter(column -> ImmutableSet.of("t_bigint", "t_complex", "t_struct_nested").contains(column.getName()))
+                .collect(toList());
         Optional<ConnectorPageSource> pageSource = HivePageSourceProvider.createHivePageSource(
                 ImmutableSet.of(cursorProvider),
                 ImmutableSet.of(),
                 configuration,
-                SESSION,
+                session,
                 split.getPath(),
                 OptionalInt.empty(),
                 split.getStart(),
                 split.getLength(),
                 split.getLength(),
                 splitProperties,
-                TupleDomain.all(),
+                createEffectivePredicate(predicateColumns),
                 getColumnHandles(testColumns),
                 partitionKeys,
                 DateTimeZone.getDefault(),
@@ -756,7 +759,9 @@ public class TestHiveFileFormats
                 .collect(toList());
 
         List<HiveColumnHandle> columnHandles = getColumnHandles(testColumns);
-
+        List<TestColumn> predicateColumns = TEST_COLUMNS.stream()
+                .filter(column -> ImmutableSet.of("t_bigint", "t_complex", "t_struct_nested").contains(column.getName()))
+                .collect(toList());
         Optional<ConnectorPageSource> pageSource = HivePageSourceProvider.createHivePageSource(
                 ImmutableSet.of(),
                 ImmutableSet.of(sourceFactory),
@@ -768,7 +773,7 @@ public class TestHiveFileFormats
                 split.getLength(),
                 split.getLength(),
                 splitProperties,
-                TupleDomain.all(),
+                createEffectivePredicate(predicateColumns),
                 columnHandles,
                 partitionKeys,
                 DateTimeZone.getDefault(),
@@ -954,7 +959,7 @@ public class TestHiveFileFormats
                     testPageSourceFactory(pageSourceFactory.get(), split, storageFormat, readColumns, session, rowsCount);
                 }
                 if (cursorProvider.isPresent()) {
-                    testCursorProvider(cursorProvider.get(), split, storageFormat, readColumns, rowsCount);
+                    testCursorProvider(cursorProvider.get(), split, storageFormat, readColumns, session, rowsCount);
                 }
             }
             finally {


### PR DESCRIPTION
`getParquetTupleDomain()` create incorrect `parquetTupleDomain` when the `effectivePredicate` is a complex type (e.g., row type).