### PR TITLE
remove --enable-authentication flag

### DIFF
--- a/presto-cli/src/main/java/com/facebook/presto/cli/ClientOptions.java
+++ b/presto-cli/src/main/java/com/facebook/presto/cli/ClientOptions.java
@@ -48,9 +48,6 @@ public class ClientOptions
     @Option(name = "--server", title = "server", description = "Presto server location (default: localhost:8080)")
     public String server = "localhost:8080";
 
-    @Option(name = "--enable-authentication", title = "enable authentication", description = "Enable client authentication")
-    public boolean authenticationEnabled;
-
     @Option(name = "--krb5-remote-service-name", title = "krb5 remote service name", description = "Remote peer's kerberos service name")
     public String krb5RemoteServiceName;
 

--- a/presto-cli/src/main/java/com/facebook/presto/cli/Console.java
+++ b/presto-cli/src/main/java/com/facebook/presto/cli/Console.java
@@ -136,8 +136,7 @@ public class Console
                 Optional.ofNullable(clientOptions.krb5ConfigPath),
                 Optional.ofNullable(clientOptions.krb5KeytabPath),
                 Optional.ofNullable(clientOptions.krb5CredentialCachePath),
-                !clientOptions.krb5DisableRemoteServiceHostnameCanonicalization,
-                clientOptions.authenticationEnabled)) {
+                !clientOptions.krb5DisableRemoteServiceHostnameCanonicalization)) {
             if (hasQuery) {
                 executeCommand(queryRunner, query, clientOptions.outputFormat);
             }

--- a/presto-cli/src/main/java/com/facebook/presto/cli/QueryRunner.java
+++ b/presto-cli/src/main/java/com/facebook/presto/cli/QueryRunner.java
@@ -71,6 +71,8 @@ public class QueryRunner
         setupBasicAuth(builder, session, user, password);
 
         if (kerberosRemoteServiceName.isPresent()) {
+            checkArgument(session.getServer().getScheme().equalsIgnoreCase("https"),
+                    "Authentication using Kerberos requires HTTPS to be enabled");
             setupKerberos(
                     builder,
                     kerberosRemoteServiceName.get(),

--- a/presto-cli/src/main/java/com/facebook/presto/cli/QueryRunner.java
+++ b/presto-cli/src/main/java/com/facebook/presto/cli/QueryRunner.java
@@ -13,7 +13,6 @@
  */
 package com.facebook.presto.cli;
 
-import com.facebook.presto.client.ClientException;
 import com.facebook.presto.client.ClientSession;
 import com.facebook.presto.client.StatementClient;
 import com.google.common.net.HostAndPort;
@@ -58,8 +57,7 @@ public class QueryRunner
             Optional<String> kerberosConfigPath,
             Optional<String> kerberosKeytabPath,
             Optional<String> kerberosCredentialCachePath,
-            boolean kerberosUseCanonicalHostname,
-            boolean kerberosEnabled)
+            boolean kerberosUseCanonicalHostname)
     {
         this.session = new AtomicReference<>(requireNonNull(session, "session is null"));
 
@@ -72,10 +70,10 @@ public class QueryRunner
         setupHttpProxy(builder, httpProxy);
         setupBasicAuth(builder, session, user, password);
 
-        if (kerberosEnabled) {
+        if (kerberosRemoteServiceName.isPresent()) {
             setupKerberos(
                     builder,
-                    kerberosRemoteServiceName.orElseThrow(() -> new ClientException("Kerberos remote service name must be set")),
+                    kerberosRemoteServiceName.get(),
                     kerberosUseCanonicalHostname,
                     kerberosPrincipal,
                     kerberosConfigPath.map(File::new),

--- a/presto-cli/src/test/java/com/facebook/presto/cli/TestTableNameCompleter.java
+++ b/presto-cli/src/test/java/com/facebook/presto/cli/TestTableNameCompleter.java
@@ -42,7 +42,6 @@ public class TestTableNameCompleter
                 Optional.empty(),
                 Optional.empty(),
                 Optional.empty(),
-                false,
                 false);
         TableNameCompleter completer = new TableNameCompleter(runner);
         assertEquals(completer.complete("SELECT is_infi", 14, ImmutableList.of()), 7);

--- a/presto-docs/src/main/sphinx/security/cli.rst
+++ b/presto-docs/src/main/sphinx/security/cli.rst
@@ -57,7 +57,6 @@ options. The simplest way to invoke the CLI is with a wrapper script.
 
     ./presto \
       --server https://presto-coordinator.example.com:7778 \
-      --enable-authentication \
       --krb5-config-path /etc/krb5.conf \
       --krb5-principal someuser@EXAMPLE.COM \
       --krb5-keytab-path /home/someuser/someuser.keytab \
@@ -73,7 +72,6 @@ Option                          Description
 ``--server``                    The address and port of the Presto coordinator.  The port must
                                 be set to the port the Presto coordinator is listening for HTTPS
                                 connections on.
-``--enable-authentication``     Enables Kerberos authentication.
 ``--krb5-config-path``          Kerberos configuration file.
 ``--krb5-principal``            The principal to use when authenticating to the coordinator.
 ``--krb5-keytab-path``          The location of the the keytab that can be used to
@@ -108,7 +106,6 @@ file cannot pass the option to the JVM.
       -Dsun.security.krb5.debug=true \
       -jar presto-cli-*-executable.jar \
       --server https://presto-coordinator.example.com:7778 \
-      --enable-authentication \
       --krb5-config-path /etc/krb5.conf \
       --krb5-principal someuser@EXAMPLE.COM \
       --krb5-keytab-path /home/someuser/someuser.keytab \

--- a/presto-product-tests/bin/run_on_docker.sh
+++ b/presto-product-tests/bin/run_on_docker.sh
@@ -181,7 +181,7 @@ if [[ "$ENVIRONMENT" == "multinode-tls" || "$ENVIRONMENT" == *kerberos* ]]; then
     CLI_ARGUMENTS="--server https://presto-master.docker.cluster:7778 --keystore-path /docker/volumes/conf/presto/etc/docker.cluster.jks --keystore-password 123456"
 fi
 if [[ "$ENVIRONMENT" == *kerberos* ]]; then
-    CLI_ARGUMENTS="${CLI_ARGUMENTS} --enable-authentication --krb5-config-path /etc/krb5.conf --krb5-principal presto-client/presto-master.docker.cluster@LABS.TERADATA.COM --krb5-keytab-path /etc/presto/conf/presto-client.keytab --krb5-remote-service-name presto-server --krb5-disable-remote-service-hostname-canonicalization"
+    CLI_ARGUMENTS="${CLI_ARGUMENTS} --krb5-config-path /etc/krb5.conf --krb5-principal presto-client/presto-master.docker.cluster@LABS.TERADATA.COM --krb5-keytab-path /etc/presto/conf/presto-client.keytab --krb5-remote-service-name presto-server --krb5-disable-remote-service-hostname-canonicalization"
 fi
 
 # check docker and docker compose installation

--- a/presto-product-tests/src/main/java/com/facebook/presto/tests/cli/PrestoCliTests.java
+++ b/presto-product-tests/src/main/java/com/facebook/presto/tests/cli/PrestoCliTests.java
@@ -245,7 +245,6 @@ public class PrestoCliTests
             requireNonNull(kerberosServiceName, "databases.presto.cli_kerberos_service_name is null");
             requireNonNull(kerberosConfigPath, "databases.presto.cli_kerberos_config_path is null");
 
-            prestoClientOptions.add("--enable-authentication");
             prestoClientOptions.add("--krb5-principal", kerberosPrincipal);
             prestoClientOptions.add("--krb5-keytab-path", kerberosKeytab);
             prestoClientOptions.add("--krb5-remote-service-name", kerberosServiceName);


### PR DESCRIPTION
`--enable-authentication` flag in `presto-cli` is misleading because we can have both Password authentication and Kerberos authentication turned on for server side but this flag doesn't state clear which method it's using.
Given the `kerberosRemoteServiceName` variable is required for Kerberos based authentication, we can use the present of `--krb5-remote-service-name` value to determined whether the client should setup Kerberos.  This behavior has already employed in `presto-jdbc`.