### PR TITLE
Fix complex parquet type

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/parquet/Field.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/parquet/Field.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.hive.parquet;
+
+import com.facebook.presto.spi.type.Type;
+
+public abstract class Field
+{
+    private final Type type;
+    private final int repetitionLevel;
+    private final int definitionLevel;
+    private final boolean required;
+
+    protected Field(Type type, int repetitionLevel, int definitionLevel, boolean required)
+    {
+        this.type = type;
+        this.repetitionLevel = repetitionLevel;
+        this.definitionLevel = definitionLevel;
+        this.required = required;
+    }
+
+    public Type getType()
+    {
+        return type;
+    }
+
+    public int getRepetitionLevel()
+    {
+        return repetitionLevel;
+    }
+
+    public int getDefinitionLevel()
+    {
+        return definitionLevel;
+    }
+
+    public boolean isRequired()
+    {
+        return required;
+    }
+}

--- a/presto-hive/src/main/java/com/facebook/presto/hive/parquet/GroupField.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/parquet/GroupField.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.hive.parquet;
+
+import com.facebook.presto.spi.type.Type;
+
+import java.util.List;
+import java.util.Optional;
+
+public class GroupField
+        extends Field
+{
+    private final List<Optional<Field>> children;
+
+    public GroupField(Type type, int repetitionLevel, int definitionLevel, boolean required, List<Optional<Field>> children)
+    {
+        super(type, repetitionLevel, definitionLevel, required);
+        this.children = children;
+    }
+
+    public List<Optional<Field>> getChildren()
+    {
+        return children;
+    }
+}

--- a/presto-hive/src/main/java/com/facebook/presto/hive/parquet/ParquetHiveRecordCursor.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/parquet/ParquetHiveRecordCursor.java
@@ -72,6 +72,7 @@ import static com.facebook.presto.hive.HiveErrorCode.HIVE_MISSING_DATA;
 import static com.facebook.presto.hive.HiveUtil.closeWithSuppression;
 import static com.facebook.presto.hive.HiveUtil.getDecimalType;
 import static com.facebook.presto.hive.parquet.HdfsParquetDataSource.buildHdfsParquetDataSource;
+import static com.facebook.presto.hive.parquet.ParquetTypeUtils.getDescriptors;
 import static com.facebook.presto.hive.parquet.ParquetTypeUtils.getParquetType;
 import static com.facebook.presto.hive.parquet.predicate.ParquetPredicateUtils.buildParquetPredicate;
 import static com.facebook.presto.hive.parquet.predicate.ParquetPredicateUtils.getParquetTupleDomain;
@@ -345,9 +346,10 @@ public class ParquetHiveRecordCursor
                 long firstDataPage = block.getColumns().get(0).getFirstDataPageOffset();
                 if (firstDataPage >= start && firstDataPage < start + length) {
                     if (predicatePushdownEnabled) {
-                        TupleDomain<ColumnDescriptor> parquetTupleDomain = getParquetTupleDomain(fileSchema, requestedSchema, effectivePredicate);
-                        ParquetPredicate parquetPredicate = buildParquetPredicate(requestedSchema, parquetTupleDomain, fileSchema);
-                        if (predicateMatches(parquetPredicate, block, dataSource, fileSchema, requestedSchema, parquetTupleDomain)) {
+                        Map<List<String>, RichColumnDescriptor> descriptorsByPath = getDescriptors(fileSchema, requestedSchema);
+                        TupleDomain<ColumnDescriptor> parquetTupleDomain = getParquetTupleDomain(descriptorsByPath, effectivePredicate);
+                        ParquetPredicate parquetPredicate = buildParquetPredicate(requestedSchema, parquetTupleDomain, descriptorsByPath);
+                        if (predicateMatches(parquetPredicate, block, dataSource, descriptorsByPath, parquetTupleDomain)) {
                             offsets.add(block.getStartingPos());
                         }
                     }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/parquet/ParquetPageSource.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/parquet/ParquetPageSource.java
@@ -39,12 +39,13 @@ import java.util.Properties;
 import static com.facebook.presto.hive.HiveColumnHandle.ColumnType.REGULAR;
 import static com.facebook.presto.hive.HiveErrorCode.HIVE_BAD_DATA;
 import static com.facebook.presto.hive.HiveErrorCode.HIVE_CURSOR_ERROR;
-import static com.facebook.presto.hive.parquet.ParquetTypeUtils.getFieldIndex;
+import static com.facebook.presto.hive.parquet.ParquetTypeUtils.findFieldIndexByName;
 import static com.facebook.presto.hive.parquet.ParquetTypeUtils.getParquetType;
 import static com.google.common.base.Preconditions.checkState;
 import static java.util.Collections.unmodifiableList;
 import static java.util.Objects.requireNonNull;
 import static parquet.io.ColumnIOConverter.constructField;
+import static parquet.io.ColumnIOConverter.findColumnIObyName;
 
 public class ParquetPageSource
         implements ConnectorPageSource
@@ -107,7 +108,7 @@ public class ParquetPageSource
             }
             else {
                 String columnName = useParquetColumnNames ? name : fileSchema.getFields().get(column.getHiveColumnIndex()).getName();
-                fieldsList.add(constructField(type, messageColumnIO.getChild(columnName)));
+                fieldsList.add(constructField(type, findColumnIObyName(messageColumnIO, columnName)));
             }
         }
         types = typesBuilder.build();
@@ -163,7 +164,7 @@ public class ParquetPageSource
                 else {
                     Type type = types.get(fieldId);
                     Optional<Field> field = fields.get(fieldId);
-                    int fieldIndex = useParquetColumnNames ? getFieldIndex(fileSchema, columnNames.get(fieldId)) : hiveColumnIndexes[fieldId];
+                    int fieldIndex = useParquetColumnNames ? findFieldIndexByName(fileSchema, columnNames.get(fieldId)) : hiveColumnIndexes[fieldId];
                     if (fieldIndex != -1 && field.isPresent()) {
                         blocks[fieldId] = new LazyBlock(batchSize, new ParquetBlockLoader(field.get()));
                     }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/parquet/ParquetPageSourceFactory.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/parquet/ParquetPageSourceFactory.java
@@ -36,6 +36,7 @@ import parquet.column.ColumnDescriptor;
 import parquet.hadoop.metadata.BlockMetaData;
 import parquet.hadoop.metadata.FileMetaData;
 import parquet.hadoop.metadata.ParquetMetadata;
+import parquet.io.MessageColumnIO;
 import parquet.schema.MessageType;
 
 import javax.inject.Inject;
@@ -44,6 +45,7 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Properties;
@@ -56,6 +58,8 @@ import static com.facebook.presto.hive.HiveSessionProperties.isParquetOptimizedR
 import static com.facebook.presto.hive.HiveSessionProperties.isParquetPredicatePushdownEnabled;
 import static com.facebook.presto.hive.HiveUtil.getDeserializerClassName;
 import static com.facebook.presto.hive.parquet.HdfsParquetDataSource.buildHdfsParquetDataSource;
+import static com.facebook.presto.hive.parquet.ParquetTypeUtils.getColumnIO;
+import static com.facebook.presto.hive.parquet.ParquetTypeUtils.getDescriptors;
 import static com.facebook.presto.hive.parquet.ParquetTypeUtils.getParquetType;
 import static com.facebook.presto.hive.parquet.predicate.ParquetPredicateUtils.buildParquetPredicate;
 import static com.facebook.presto.hive.parquet.predicate.ParquetPredicateUtils.getParquetTupleDomain;
@@ -171,33 +175,30 @@ public class ParquetPageSourceFactory
             }
 
             if (predicatePushdownEnabled) {
-                TupleDomain<ColumnDescriptor> parquetTupleDomain = getParquetTupleDomain(fileSchema, requestedSchema, effectivePredicate);
-                ParquetPredicate parquetPredicate = buildParquetPredicate(requestedSchema, parquetTupleDomain, fileMetaData.getSchema());
+                Map<List<String>, RichColumnDescriptor> descriptorsByPath = getDescriptors(fileSchema, requestedSchema);
+                TupleDomain<ColumnDescriptor> parquetTupleDomain = getParquetTupleDomain(descriptorsByPath, effectivePredicate);
+                ParquetPredicate parquetPredicate = buildParquetPredicate(requestedSchema, parquetTupleDomain, descriptorsByPath);
                 final ParquetDataSource finalDataSource = dataSource;
                 blocks = blocks.stream()
-                        .filter(block -> predicateMatches(parquetPredicate, block, finalDataSource, fileSchema, requestedSchema, parquetTupleDomain))
+                        .filter(block -> predicateMatches(parquetPredicate, block, finalDataSource, descriptorsByPath, parquetTupleDomain))
                         .collect(toList());
             }
-
+            MessageColumnIO messageColumnIO = getColumnIO(fileSchema, requestedSchema);
             ParquetReader parquetReader = new ParquetReader(
-                    fileSchema,
-                    requestedSchema,
+                    messageColumnIO,
                     blocks,
                     dataSource,
-                    typeManager,
                     systemMemoryContext);
 
             return new ParquetPageSource(
                     parquetReader,
-                    dataSource,
                     fileSchema,
-                    requestedSchema,
+                    messageColumnIO,
+                    typeManager,
                     schema,
                     columns,
                     effectivePredicate,
-                    typeManager,
-                    useParquetColumnNames,
-                    systemMemoryContext);
+                    useParquetColumnNames);
         }
         catch (Exception e) {
             try {

--- a/presto-hive/src/main/java/com/facebook/presto/hive/parquet/ParquetTypeUtils.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/parquet/ParquetTypeUtils.java
@@ -24,23 +24,28 @@ import com.facebook.presto.spi.type.RealType;
 import com.facebook.presto.spi.type.TimestampType;
 import com.facebook.presto.spi.type.Type;
 import com.facebook.presto.spi.type.VarcharType;
-import parquet.column.ColumnDescriptor;
 import parquet.column.Encoding;
 import parquet.io.ColumnIO;
 import parquet.io.ColumnIOFactory;
+import parquet.io.GroupColumnIO;
 import parquet.io.InvalidRecordException;
+import parquet.io.MessageColumnIO;
 import parquet.io.ParquetDecodingException;
 import parquet.io.PrimitiveColumnIO;
 import parquet.schema.DecimalMetadata;
 import parquet.schema.MessageType;
 
+import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 import static com.facebook.presto.spi.StandardErrorCode.NOT_SUPPORTED;
 import static com.google.common.base.Preconditions.checkArgument;
 import static java.util.Optional.empty;
 import static parquet.schema.OriginalType.DECIMAL;
+import static parquet.schema.Type.Repetition.REPEATED;
 
 public final class ParquetTypeUtils
 {
@@ -53,27 +58,56 @@ public final class ParquetTypeUtils
         return (new ColumnIOFactory()).getColumnIO(requestedSchema, fileSchema, true).getLeaves();
     }
 
-    public static Optional<RichColumnDescriptor> getDescriptor(MessageType fileSchema, MessageType requestedSchema, List<String> path)
+    public static MessageColumnIO getColumnIO(MessageType fileSchema, MessageType requestedSchema)
     {
-        checkArgument(path.size() >= 1, "Parquet nested path should have at least one component");
-        int index = getPathIndex(fileSchema, requestedSchema, path);
-        return getDescriptor(fileSchema, requestedSchema, index);
+        return (new ColumnIOFactory()).getColumnIO(requestedSchema, fileSchema, true);
     }
 
-    public static Optional<RichColumnDescriptor> getDescriptor(MessageType fileSchema, MessageType requestedSchema, int index)
+    public static GroupColumnIO getMapKeyValueColumn(GroupColumnIO groupColumnIO)
     {
+        while (groupColumnIO.getChildrenCount() == 1) {
+            groupColumnIO = (GroupColumnIO) groupColumnIO.getChild(0);
+        }
+        return groupColumnIO;
+    }
+
+    public static ColumnIO getArrayElementColumn(ColumnIO columnIO)
+    {
+        while ((columnIO instanceof GroupColumnIO) && !columnIO.getType().isRepetition(REPEATED)) {
+            columnIO = ((GroupColumnIO) columnIO).getChild(0);
+        }
+        if (columnIO instanceof GroupColumnIO && columnIO.getType().getOriginalType() == null && ((GroupColumnIO) columnIO).getChildrenCount() == 1) {
+            return ((GroupColumnIO) columnIO).getChild(0);
+        }
+        return columnIO;
+    }
+
+    public static Map<List<String>, RichColumnDescriptor> getDescriptors(MessageType fileSchema, MessageType requestedSchema)
+    {
+        Map<List<String>, RichColumnDescriptor> descriptorsByPath = new HashMap<>();
+        List<PrimitiveColumnIO> columns = getColumns(fileSchema, requestedSchema);
+        for (String[] paths : fileSchema.getPaths()) {
+            List<String> columnPath = Arrays.asList(paths);
+            getDescriptor(columns, columnPath)
+                    .ifPresent(richColumnDescriptor -> descriptorsByPath.put(columnPath, richColumnDescriptor));
+        }
+        return descriptorsByPath;
+    }
+
+    public static Optional<RichColumnDescriptor> getDescriptor(List<PrimitiveColumnIO> columns, List<String> path)
+    {
+        checkArgument(path.size() >= 1, "Parquet nested path should have at least one component");
+        int index = getPathIndex(columns, path);
         if (index == -1) {
             return empty();
         }
-        PrimitiveColumnIO columnIO = getColumns(fileSchema, requestedSchema).get(index);
-        ColumnDescriptor descriptor = columnIO.getColumnDescriptor();
-        return Optional.of(new RichColumnDescriptor(descriptor.getPath(), columnIO.getType().asPrimitiveType(), descriptor.getMaxRepetitionLevel(), descriptor.getMaxDefinitionLevel()));
+        PrimitiveColumnIO columnIO = columns.get(index);
+        return Optional.of(new RichColumnDescriptor(columnIO.getColumnDescriptor(), columnIO.getType().asPrimitiveType()));
     }
 
-    private static int getPathIndex(MessageType fileSchema, MessageType requestedSchema, List<String> path)
+    private static int getPathIndex(List<PrimitiveColumnIO> columns, List<String> path)
     {
         int maxLevel = path.size();
-        List<PrimitiveColumnIO> columns = getColumns(fileSchema, requestedSchema);
         int index = -1;
         for (int columnIndex = 0; columnIndex < columns.size(); columnIndex++) {
             ColumnIO[] fields = columns.get(columnIndex).getPath();
@@ -123,7 +157,7 @@ public final class ParquetTypeUtils
     public static int getFieldIndex(MessageType fileSchema, String name)
     {
         try {
-            return fileSchema.getFieldIndex(name);
+            return fileSchema.getFieldIndex(name.toLowerCase());
         }
         catch (InvalidRecordException e) {
             for (parquet.schema.Type type : fileSchema.getFields()) {
@@ -231,5 +265,16 @@ public final class ParquetTypeUtils
         }
         DecimalMetadata decimalMetadata = descriptor.getPrimitiveType().getDecimalMetadata();
         return Optional.of(DecimalType.createDecimalType(decimalMetadata.getPrecision(), decimalMetadata.getScale()));
+    }
+
+    /**
+     * For optional fields:
+     * definitionLevel == maxDefinitionLevel     => Value is defined
+     * definitionLevel == maxDefinitionLevel - 1 => Value is null
+     * definitionLevel < maxDefinitionLevel - 1  => Value does not exist, because one of its optional parent fields is null
+     */
+    public static boolean isValueNull(boolean required, int definitionLevel, int maxDefinitionLevel)
+    {
+        return !required && (definitionLevel == maxDefinitionLevel - 1);
     }
 }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/parquet/PrimitiveField.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/parquet/PrimitiveField.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.hive.parquet;
+
+import com.facebook.presto.spi.type.Type;
+
+public class PrimitiveField
+        extends Field
+{
+    private final RichColumnDescriptor descriptor;
+    private final int id;
+
+    public PrimitiveField(Type type, int repetitionLevel, int definitionLevel, boolean required, RichColumnDescriptor descriptor, int id)
+    {
+        super(type, repetitionLevel, definitionLevel, required);
+        this.descriptor = descriptor;
+        this.id = id;
+    }
+
+    public RichColumnDescriptor getDescriptor()
+    {
+        return descriptor;
+    }
+
+    public int getId()
+    {
+        return id;
+    }
+}

--- a/presto-hive/src/main/java/com/facebook/presto/hive/parquet/RichColumnDescriptor.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/parquet/RichColumnDescriptor.java
@@ -16,24 +16,31 @@ package com.facebook.presto.hive.parquet;
 import parquet.column.ColumnDescriptor;
 import parquet.schema.PrimitiveType;
 
+import static parquet.schema.Type.Repetition.OPTIONAL;
+
 // extension of parquet's ColumnDescriptor. Exposes full Primitive type information
 public class RichColumnDescriptor
         extends ColumnDescriptor
 {
     private final PrimitiveType primitiveType;
+    private final boolean required;
 
     public RichColumnDescriptor(
-            String[] path,
-            PrimitiveType primitiveType,
-            int maxRep,
-            int maxDef)
+            ColumnDescriptor descriptor,
+            PrimitiveType primitiveType)
     {
-        super(path, primitiveType.getPrimitiveTypeName(), primitiveType.getTypeLength(), maxRep, maxDef);
+        super(descriptor.getPath(), primitiveType.getPrimitiveTypeName(), primitiveType.getTypeLength(), descriptor.getMaxRepetitionLevel(), descriptor.getMaxDefinitionLevel());
         this.primitiveType = primitiveType;
+        this.required = primitiveType.getRepetition() != OPTIONAL;
     }
 
     public PrimitiveType getPrimitiveType()
     {
         return primitiveType;
+    }
+
+    public boolean isRequired()
+    {
+        return required;
     }
 }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/parquet/predicate/ParquetPredicateUtils.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/parquet/predicate/ParquetPredicateUtils.java
@@ -42,12 +42,12 @@ import parquet.schema.MessageType;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.util.Arrays;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
 import static com.facebook.presto.hive.parquet.ParquetCompressionUtils.decompress;
-import static com.facebook.presto.hive.parquet.ParquetTypeUtils.getDescriptor;
 import static com.facebook.presto.hive.parquet.ParquetTypeUtils.getParquetEncoding;
 import static com.facebook.presto.spi.type.IntegerType.INTEGER;
 import static com.facebook.presto.spi.type.SmallintType.SMALLINT;
@@ -75,7 +75,7 @@ public final class ParquetPredicateUtils
                 (type.equals(INTEGER) && (min < Integer.MIN_VALUE || max > Integer.MAX_VALUE));
     }
 
-    public static TupleDomain<ColumnDescriptor> getParquetTupleDomain(MessageType fileSchema, MessageType requestedSchema, TupleDomain<HiveColumnHandle> effectivePredicate)
+    public static TupleDomain<ColumnDescriptor> getParquetTupleDomain(Map<List<String>, RichColumnDescriptor> descriptorsByPath, TupleDomain<HiveColumnHandle> effectivePredicate)
     {
         if (effectivePredicate.isNone()) {
             return TupleDomain.none();
@@ -83,65 +83,66 @@ public final class ParquetPredicateUtils
 
         ImmutableMap.Builder<ColumnDescriptor, Domain> predicate = ImmutableMap.builder();
         for (Entry<HiveColumnHandle, Domain> entry : effectivePredicate.getDomains().get().entrySet()) {
-            Optional<RichColumnDescriptor> descriptor = getDescriptor(fileSchema, requestedSchema, ImmutableList.of(entry.getKey().getName()));
-            if (descriptor.isPresent()) {
-                predicate.put(descriptor.get(), entry.getValue());
+            RichColumnDescriptor descriptor = descriptorsByPath.get(ImmutableList.of(entry.getKey().getName()));
+            if (descriptor != null) {
+                predicate.put(descriptor, entry.getValue());
             }
         }
         return TupleDomain.withColumnDomains(predicate.build());
     }
 
-    public static ParquetPredicate buildParquetPredicate(MessageType requestedSchema, TupleDomain<ColumnDescriptor> parquetTupleDomain, MessageType fileSchema)
+    public static ParquetPredicate buildParquetPredicate(MessageType requestedSchema, TupleDomain<ColumnDescriptor> parquetTupleDomain, Map<List<String>, RichColumnDescriptor> descriptorsByPath)
     {
         ImmutableList.Builder<RichColumnDescriptor> columnReferences = ImmutableList.builder();
         for (String[] paths : requestedSchema.getPaths()) {
-            Optional<RichColumnDescriptor> descriptor = getDescriptor(fileSchema, requestedSchema, Arrays.asList(paths));
-            if (descriptor.isPresent()) {
-                columnReferences.add(descriptor.get());
+            RichColumnDescriptor descriptor = descriptorsByPath.get(Arrays.asList(paths));
+            if (descriptor != null) {
+                columnReferences.add(descriptor);
             }
         }
         return new TupleDomainParquetPredicate(parquetTupleDomain, columnReferences.build());
     }
 
-    public static boolean predicateMatches(ParquetPredicate parquetPredicate, BlockMetaData block, ParquetDataSource dataSource, MessageType fileSchema, MessageType requestedSchema, TupleDomain<ColumnDescriptor> parquetTupleDomain)
+    public static boolean predicateMatches(ParquetPredicate parquetPredicate, BlockMetaData block, ParquetDataSource dataSource,
+            Map<List<String>, RichColumnDescriptor> descriptorsByPath, TupleDomain<ColumnDescriptor> parquetTupleDomain)
     {
-        Map<ColumnDescriptor, Statistics<?>> columnStatistics = getStatistics(block, fileSchema, requestedSchema);
+        Map<ColumnDescriptor, Statistics<?>> columnStatistics = getStatistics(block, descriptorsByPath);
         if (!parquetPredicate.matches(block.getRowCount(), columnStatistics)) {
             return false;
         }
 
-        Map<ColumnDescriptor, ParquetDictionaryDescriptor> dictionaries = getDictionaries(block, dataSource, fileSchema, requestedSchema, parquetTupleDomain);
+        Map<ColumnDescriptor, ParquetDictionaryDescriptor> dictionaries = getDictionaries(block, dataSource, descriptorsByPath, parquetTupleDomain);
         return parquetPredicate.matches(dictionaries);
     }
 
-    private static Map<ColumnDescriptor, Statistics<?>> getStatistics(BlockMetaData blockMetadata, MessageType fileSchema, MessageType requestedSchema)
+    private static Map<ColumnDescriptor, Statistics<?>> getStatistics(BlockMetaData blockMetadata, Map<List<String>, RichColumnDescriptor> descriptorsByPath)
     {
         ImmutableMap.Builder<ColumnDescriptor, Statistics<?>> statistics = ImmutableMap.builder();
         for (ColumnChunkMetaData columnMetaData : blockMetadata.getColumns()) {
             Statistics<?> columnStatistics = columnMetaData.getStatistics();
             if (columnStatistics != null) {
-                Optional<RichColumnDescriptor> descriptor = getDescriptor(fileSchema, requestedSchema, Arrays.asList(columnMetaData.getPath().toArray()));
-                if (descriptor.isPresent()) {
-                    statistics.put(descriptor.get(), columnStatistics);
+                RichColumnDescriptor descriptor = descriptorsByPath.get(Arrays.asList(columnMetaData.getPath().toArray()));
+                if (descriptor != null) {
+                    statistics.put(descriptor, columnStatistics);
                 }
             }
         }
         return statistics.build();
     }
 
-    private static Map<ColumnDescriptor, ParquetDictionaryDescriptor> getDictionaries(BlockMetaData blockMetadata, ParquetDataSource dataSource, MessageType fileSchema, MessageType requestedSchema, TupleDomain<ColumnDescriptor> parquetTupleDomain)
+    private static Map<ColumnDescriptor, ParquetDictionaryDescriptor> getDictionaries(BlockMetaData blockMetadata, ParquetDataSource dataSource,
+            Map<List<String>, RichColumnDescriptor> descriptorsByPath, TupleDomain<ColumnDescriptor> parquetTupleDomain)
     {
         ImmutableMap.Builder<ColumnDescriptor, ParquetDictionaryDescriptor> dictionaries = ImmutableMap.builder();
         for (ColumnChunkMetaData columnMetaData : blockMetadata.getColumns()) {
-            Optional<RichColumnDescriptor> descriptor = getDescriptor(fileSchema, requestedSchema, Arrays.asList(columnMetaData.getPath().toArray()));
-            if (descriptor.isPresent()) {
-                ColumnDescriptor columnDescriptor = descriptor.get();
-                if (isOnlyDictionaryEncodingPages(columnMetaData.getEncodings()) && isColumnPredicate(columnDescriptor, parquetTupleDomain)) {
+            RichColumnDescriptor descriptor = descriptorsByPath.get(Arrays.asList(columnMetaData.getPath().toArray()));
+            if (descriptor != null) {
+                if (isOnlyDictionaryEncodingPages(columnMetaData.getEncodings()) && isColumnPredicate(descriptor, parquetTupleDomain)) {
                     int totalSize = toIntExact(columnMetaData.getTotalSize());
                     byte[] buffer = new byte[totalSize];
                     dataSource.readFully(columnMetaData.getStartingPos(), buffer);
                     Optional<ParquetDictionaryPage> dictionaryPage = readDictionaryPage(buffer, columnMetaData.getCodec());
-                    dictionaries.put(columnDescriptor, new ParquetDictionaryDescriptor(columnDescriptor, dictionaryPage));
+                    dictionaries.put(descriptor, new ParquetDictionaryDescriptor(descriptor, dictionaryPage));
                     break;
                 }
             }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/parquet/reader/ColumnChunk.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/parquet/reader/ColumnChunk.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.hive.parquet.reader;
+
+import com.facebook.presto.spi.block.Block;
+
+public class ColumnChunk
+{
+    private final Block block;
+    private final int[] definitionLevels;
+    private final int[] repetitionLevels;
+
+    public ColumnChunk(Block block, int[] definitionLevels, int[] repetitionLevels)
+    {
+        this.block = block;
+        this.definitionLevels = definitionLevels;
+        this.repetitionLevels = repetitionLevels;
+    }
+
+    public Block getBlock()
+    {
+        return block;
+    }
+
+    public int[] getDefinitionLevels()
+    {
+        return definitionLevels;
+    }
+
+    public int[] getRepetitionLevels()
+    {
+        return repetitionLevels;
+    }
+}

--- a/presto-hive/src/main/java/com/facebook/presto/hive/parquet/reader/ParquetBinaryColumnReader.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/parquet/reader/ParquetBinaryColumnReader.java
@@ -13,10 +13,10 @@
  */
 package com.facebook.presto.hive.parquet.reader;
 
+import com.facebook.presto.hive.parquet.RichColumnDescriptor;
 import com.facebook.presto.spi.block.BlockBuilder;
 import com.facebook.presto.spi.type.Type;
 import io.airlift.slice.Slice;
-import parquet.column.ColumnDescriptor;
 import parquet.io.api.Binary;
 
 import static com.facebook.presto.spi.type.Chars.isCharType;
@@ -27,9 +27,9 @@ import static io.airlift.slice.Slices.EMPTY_SLICE;
 import static io.airlift.slice.Slices.wrappedBuffer;
 
 public class ParquetBinaryColumnReader
-        extends ParquetColumnReader
+        extends ParquetPrimitiveColumnReader
 {
-    public ParquetBinaryColumnReader(ColumnDescriptor descriptor)
+    public ParquetBinaryColumnReader(RichColumnDescriptor descriptor)
     {
         super(descriptor);
     }
@@ -54,7 +54,7 @@ public class ParquetBinaryColumnReader
             }
             type.writeSlice(blockBuilder, value);
         }
-        else {
+        else if (isValueNull()) {
             blockBuilder.appendNull();
         }
     }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/parquet/reader/ParquetBooleanColumnReader.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/parquet/reader/ParquetBooleanColumnReader.java
@@ -13,14 +13,14 @@
  */
 package com.facebook.presto.hive.parquet.reader;
 
+import com.facebook.presto.hive.parquet.RichColumnDescriptor;
 import com.facebook.presto.spi.block.BlockBuilder;
 import com.facebook.presto.spi.type.Type;
-import parquet.column.ColumnDescriptor;
 
 public class ParquetBooleanColumnReader
-        extends ParquetColumnReader
+        extends ParquetPrimitiveColumnReader
 {
-    public ParquetBooleanColumnReader(ColumnDescriptor descriptor)
+    public ParquetBooleanColumnReader(RichColumnDescriptor descriptor)
     {
         super(descriptor);
     }
@@ -31,7 +31,7 @@ public class ParquetBooleanColumnReader
         if (definitionLevel == columnDescriptor.getMaxDefinitionLevel()) {
             type.writeBoolean(blockBuilder, valuesReader.readBoolean());
         }
-        else {
+        else if (isValueNull()) {
             blockBuilder.appendNull();
         }
     }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/parquet/reader/ParquetDecimalColumnReaderFactory.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/parquet/reader/ParquetDecimalColumnReaderFactory.java
@@ -20,7 +20,7 @@ public final class ParquetDecimalColumnReaderFactory
 {
     private ParquetDecimalColumnReaderFactory() {}
 
-    public static ParquetColumnReader createReader(RichColumnDescriptor descriptor, int precision, int scale)
+    public static ParquetPrimitiveColumnReader createReader(RichColumnDescriptor descriptor, int precision, int scale)
     {
         DecimalType decimalType = DecimalType.createDecimalType(precision, scale);
         if (decimalType.isShort()) {

--- a/presto-hive/src/main/java/com/facebook/presto/hive/parquet/reader/ParquetDoubleColumnReader.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/parquet/reader/ParquetDoubleColumnReader.java
@@ -13,14 +13,14 @@
  */
 package com.facebook.presto.hive.parquet.reader;
 
+import com.facebook.presto.hive.parquet.RichColumnDescriptor;
 import com.facebook.presto.spi.block.BlockBuilder;
 import com.facebook.presto.spi.type.Type;
-import parquet.column.ColumnDescriptor;
 
 public class ParquetDoubleColumnReader
-        extends ParquetColumnReader
+        extends ParquetPrimitiveColumnReader
 {
-    public ParquetDoubleColumnReader(ColumnDescriptor descriptor)
+    public ParquetDoubleColumnReader(RichColumnDescriptor descriptor)
     {
         super(descriptor);
     }
@@ -31,7 +31,7 @@ public class ParquetDoubleColumnReader
         if (definitionLevel == columnDescriptor.getMaxDefinitionLevel()) {
             type.writeDouble(blockBuilder, valuesReader.readDouble());
         }
-        else {
+        else if (isValueNull()) {
             blockBuilder.appendNull();
         }
     }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/parquet/reader/ParquetFloatColumnReader.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/parquet/reader/ParquetFloatColumnReader.java
@@ -13,16 +13,16 @@
  */
 package com.facebook.presto.hive.parquet.reader;
 
+import com.facebook.presto.hive.parquet.RichColumnDescriptor;
 import com.facebook.presto.spi.block.BlockBuilder;
 import com.facebook.presto.spi.type.Type;
-import parquet.column.ColumnDescriptor;
 
 import static java.lang.Float.floatToRawIntBits;
 
 public class ParquetFloatColumnReader
-        extends ParquetColumnReader
+        extends ParquetPrimitiveColumnReader
 {
-    public ParquetFloatColumnReader(ColumnDescriptor descriptor)
+    public ParquetFloatColumnReader(RichColumnDescriptor descriptor)
     {
         super(descriptor);
     }
@@ -33,7 +33,7 @@ public class ParquetFloatColumnReader
         if (definitionLevel == columnDescriptor.getMaxDefinitionLevel()) {
             type.writeLong(blockBuilder, floatToRawIntBits(valuesReader.readFloat()));
         }
-        else {
+        else if (isValueNull()) {
             blockBuilder.appendNull();
         }
     }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/parquet/reader/ParquetIntColumnReader.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/parquet/reader/ParquetIntColumnReader.java
@@ -13,14 +13,14 @@
  */
 package com.facebook.presto.hive.parquet.reader;
 
+import com.facebook.presto.hive.parquet.RichColumnDescriptor;
 import com.facebook.presto.spi.block.BlockBuilder;
 import com.facebook.presto.spi.type.Type;
-import parquet.column.ColumnDescriptor;
 
 public class ParquetIntColumnReader
-        extends ParquetColumnReader
+        extends ParquetPrimitiveColumnReader
 {
-    public ParquetIntColumnReader(ColumnDescriptor descriptor)
+    public ParquetIntColumnReader(RichColumnDescriptor descriptor)
     {
         super(descriptor);
     }
@@ -31,7 +31,7 @@ public class ParquetIntColumnReader
         if (definitionLevel == columnDescriptor.getMaxDefinitionLevel()) {
             type.writeLong(blockBuilder, valuesReader.readInteger());
         }
-        else {
+        else if (isValueNull()) {
             blockBuilder.appendNull();
         }
     }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/parquet/reader/ParquetListColumnReader.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/parquet/reader/ParquetListColumnReader.java
@@ -1,0 +1,96 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.hive.parquet.reader;
+
+import com.facebook.presto.hive.parquet.Field;
+import com.facebook.presto.hive.parquet.ParquetTypeUtils;
+import it.unimi.dsi.fastutil.booleans.BooleanList;
+import it.unimi.dsi.fastutil.ints.IntList;
+
+public class ParquetListColumnReader
+{
+    private ParquetListColumnReader()
+    {
+    }
+
+    /**
+     * Each collection (Array or Map) has four variants of presence:
+     * 1) Collection is not defined, because one of it's optional parent fields is null
+     * 2) Collection is null
+     * 3) Collection is defined but empty
+     * 4) Collection is defined and not empty. In this case offset value is increased by the number of elements in that collection
+     */
+    public static void calculateCollectionOffsets(Field field, IntList offsets, BooleanList collectionIsNull, int[] definitionLevels, int[] repetitionLevels)
+    {
+        int maxDefinitionLevel = field.getDefinitionLevel();
+        int maxElementRepetitionLevel = field.getRepetitionLevel() + 1;
+        boolean required = field.isRequired();
+        int offset = 0;
+        offsets.add(offset);
+        for (int i = 0; i < definitionLevels.length; i = getNextCollectionStartIndex(repetitionLevels, maxElementRepetitionLevel, i)) {
+            if (ParquetTypeUtils.isValueNull(required, definitionLevels[i], maxDefinitionLevel)) {
+                // Collection is null
+                collectionIsNull.add(true);
+                offsets.add(offset);
+            }
+            else if (definitionLevels[i] == maxDefinitionLevel) {
+                // Collection is defined but empty
+                collectionIsNull.add(false);
+                offsets.add(offset);
+            }
+            else if (definitionLevels[i] > maxDefinitionLevel) {
+                // Collection is defined and not empty
+                collectionIsNull.add(false);
+                offset += getCollectionSize(repetitionLevels, maxElementRepetitionLevel, i + 1);
+                offsets.add(offset);
+            }
+        }
+    }
+
+    private static int getNextCollectionStartIndex(int[] repetitionLevels, int maxRepetitionLevel, int elementIndex)
+    {
+        do {
+            elementIndex++;
+        }
+        while (hasMoreElements(repetitionLevels, elementIndex) && !isCollectionBeginningMarker(repetitionLevels, maxRepetitionLevel, elementIndex));
+        return elementIndex;
+    }
+
+    /**
+     * This method is only called for non-empty collections
+     */
+    private static int getCollectionSize(int[] repetitionLevels, int maxRepetitionLevel, int nextIndex)
+    {
+        int size = 1;
+        while (hasMoreElements(repetitionLevels, nextIndex) && !isCollectionBeginningMarker(repetitionLevels, maxRepetitionLevel, nextIndex)) {
+            // Collection elements can not only be primitive, but also can have nested structure
+            // Counting only elements which belong to current collection, skipping inner elements of nested collections/structs
+            if (repetitionLevels[nextIndex] <= maxRepetitionLevel) {
+                size++;
+            }
+            nextIndex++;
+        }
+        return size;
+    }
+
+    private static boolean isCollectionBeginningMarker(int[] repetitionLevels, int maxRepetitionLevel, int nextIndex)
+    {
+        return repetitionLevels[nextIndex] < maxRepetitionLevel;
+    }
+
+    private static boolean hasMoreElements(int[] repetitionLevels, int nextIndex)
+    {
+        return nextIndex < repetitionLevels.length;
+    }
+}

--- a/presto-hive/src/main/java/com/facebook/presto/hive/parquet/reader/ParquetLongColumnReader.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/parquet/reader/ParquetLongColumnReader.java
@@ -13,14 +13,14 @@
  */
 package com.facebook.presto.hive.parquet.reader;
 
+import com.facebook.presto.hive.parquet.RichColumnDescriptor;
 import com.facebook.presto.spi.block.BlockBuilder;
 import com.facebook.presto.spi.type.Type;
-import parquet.column.ColumnDescriptor;
 
 public class ParquetLongColumnReader
-        extends ParquetColumnReader
+        extends ParquetPrimitiveColumnReader
 {
-    public ParquetLongColumnReader(ColumnDescriptor descriptor)
+    public ParquetLongColumnReader(RichColumnDescriptor descriptor)
     {
         super(descriptor);
     }
@@ -31,7 +31,7 @@ public class ParquetLongColumnReader
         if (definitionLevel == columnDescriptor.getMaxDefinitionLevel()) {
             type.writeLong(blockBuilder, valuesReader.readLong());
         }
-        else {
+        else if (isValueNull()) {
             blockBuilder.appendNull();
         }
     }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/parquet/reader/ParquetLongDecimalColumnReader.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/parquet/reader/ParquetLongDecimalColumnReader.java
@@ -13,18 +13,18 @@
  */
 package com.facebook.presto.hive.parquet.reader;
 
+import com.facebook.presto.hive.parquet.RichColumnDescriptor;
 import com.facebook.presto.spi.block.BlockBuilder;
 import com.facebook.presto.spi.type.Decimals;
 import com.facebook.presto.spi.type.Type;
-import parquet.column.ColumnDescriptor;
 import parquet.io.api.Binary;
 
 import java.math.BigInteger;
 
 public class ParquetLongDecimalColumnReader
-        extends ParquetColumnReader
+        extends ParquetPrimitiveColumnReader
 {
-    ParquetLongDecimalColumnReader(ColumnDescriptor descriptor)
+    ParquetLongDecimalColumnReader(RichColumnDescriptor descriptor)
     {
         super(descriptor);
     }
@@ -36,7 +36,7 @@ public class ParquetLongDecimalColumnReader
             Binary value = valuesReader.readBytes();
             type.writeSlice(blockBuilder, Decimals.encodeUnscaledValue(new BigInteger(value.getBytes())));
         }
-        else {
+        else if (isValueNull()) {
             blockBuilder.appendNull();
         }
     }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/parquet/reader/ParquetMetadataReader.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/parquet/reader/ParquetMetadataReader.java
@@ -119,7 +119,7 @@ public final class ParquetMetadataReader
                                     || (filePath != null && filePath.equals(columnChunk.getFile_path())),
                             "all column chunks of the same row group must be in the same file");
                     ColumnMetaData metaData = columnChunk.meta_data;
-                    String[] path = metaData.path_in_schema.toArray(new String[metaData.path_in_schema.size()]);
+                    String[] path = metaData.path_in_schema.stream().map(String::toLowerCase).toArray(String[]::new);
                     ColumnPath columnPath = ColumnPath.get(path);
                     PrimitiveTypeName primitiveTypeName = messageType.getType(columnPath.toArray()).asPrimitiveType().getPrimitiveTypeName();
                     ColumnChunkMetaData column = ColumnChunkMetaData.get(
@@ -188,7 +188,7 @@ public final class ParquetMetadataReader
             if (element.isSetField_id()) {
                 typeBuilder.id(element.field_id);
             }
-            typeBuilder.named(element.name);
+            typeBuilder.named(element.name.toLowerCase());
         }
     }
 

--- a/presto-hive/src/main/java/com/facebook/presto/hive/parquet/reader/ParquetPrimitiveColumnReader.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/parquet/reader/ParquetPrimitiveColumnReader.java
@@ -13,20 +13,22 @@
  */
 package com.facebook.presto.hive.parquet.reader;
 
+import com.facebook.presto.hive.parquet.Field;
 import com.facebook.presto.hive.parquet.ParquetDataPage;
 import com.facebook.presto.hive.parquet.ParquetDataPageV1;
 import com.facebook.presto.hive.parquet.ParquetDataPageV2;
 import com.facebook.presto.hive.parquet.ParquetDictionaryPage;
 import com.facebook.presto.hive.parquet.ParquetEncoding;
+import com.facebook.presto.hive.parquet.ParquetTypeUtils;
 import com.facebook.presto.hive.parquet.RichColumnDescriptor;
 import com.facebook.presto.hive.parquet.dictionary.ParquetDictionary;
 import com.facebook.presto.spi.PrestoException;
-import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
 import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.facebook.presto.spi.type.DecimalType;
 import com.facebook.presto.spi.type.Type;
 import io.airlift.slice.Slice;
+import it.unimi.dsi.fastutil.ints.IntArrayList;
 import it.unimi.dsi.fastutil.ints.IntList;
 import parquet.bytes.BytesUtils;
 import parquet.column.ColumnDescriptor;
@@ -37,27 +39,29 @@ import parquet.io.ParquetDecodingException;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.util.Optional;
+import java.util.function.Consumer;
 
 import static com.facebook.presto.hive.parquet.ParquetTypeUtils.createDecimalType;
-import static com.facebook.presto.hive.parquet.ParquetValidationUtils.validateParquet;
 import static com.facebook.presto.hive.parquet.ParquetValuesType.DEFINITION_LEVEL;
 import static com.facebook.presto.hive.parquet.ParquetValuesType.REPETITION_LEVEL;
 import static com.facebook.presto.hive.parquet.ParquetValuesType.VALUES;
 import static com.facebook.presto.spi.StandardErrorCode.NOT_SUPPORTED;
 import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Verify.verify;
 import static java.util.Objects.requireNonNull;
 
-public abstract class ParquetColumnReader
+public abstract class ParquetPrimitiveColumnReader
 {
-    protected final ColumnDescriptor columnDescriptor;
+    private static final int EMPTY_LEVEL_VALUE = -1;
+    protected final RichColumnDescriptor columnDescriptor;
 
-    protected int definitionLevel;
+    protected int definitionLevel = EMPTY_LEVEL_VALUE;
+    protected int repetitionLevel = EMPTY_LEVEL_VALUE;
     protected ValuesReader valuesReader;
-    protected int nextBatchSize;
 
+    private int nextBatchSize;
     private ParquetLevelReader repetitionReader;
     private ParquetLevelReader definitionReader;
-    private int repetitionLevel;
     private long totalValueCount;
     private ParquetPageReader pageReader;
     private ParquetDictionary dictionary;
@@ -70,7 +74,12 @@ public abstract class ParquetColumnReader
 
     protected abstract void skipValue();
 
-    public static ParquetColumnReader createReader(RichColumnDescriptor descriptor)
+    protected boolean isValueNull()
+    {
+        return ParquetTypeUtils.isValueNull(columnDescriptor.isRequired(), definitionLevel, columnDescriptor.getMaxDefinitionLevel());
+    }
+
+    public static ParquetPrimitiveColumnReader createReader(RichColumnDescriptor descriptor)
     {
         switch (descriptor.getType()) {
             case BOOLEAN:
@@ -95,7 +104,7 @@ public abstract class ParquetColumnReader
         }
     }
 
-    private static Optional<ParquetColumnReader> createDecimalColumnReader(RichColumnDescriptor descriptor)
+    private static Optional<ParquetPrimitiveColumnReader> createDecimalColumnReader(RichColumnDescriptor descriptor)
     {
         Optional<Type> type = createDecimalType(descriptor);
         if (type.isPresent()) {
@@ -105,7 +114,7 @@ public abstract class ParquetColumnReader
         return Optional.empty();
     }
 
-    public ParquetColumnReader(ColumnDescriptor columnDescriptor)
+    public ParquetPrimitiveColumnReader(RichColumnDescriptor columnDescriptor)
     {
         this.columnDescriptor = requireNonNull(columnDescriptor, "columnDescriptor");
         pageReader = null;
@@ -147,79 +156,67 @@ public abstract class ParquetColumnReader
         return columnDescriptor;
     }
 
-    public Block readPrimitive(Type type, IntList positions)
+    public ColumnChunk readPrimitive(Field field)
             throws IOException
     {
+        IntList definitionLevels = new IntArrayList();
+        IntList repetitionLevels = new IntArrayList();
         seek();
-        BlockBuilder blockBuilder = type.createBlockBuilder(new BlockBuilderStatus(), nextBatchSize);
+        BlockBuilder blockBuilder = field.getType().createBlockBuilder(new BlockBuilderStatus(), nextBatchSize);
         int valueCount = 0;
         while (valueCount < nextBatchSize) {
             if (page == null) {
                 readNextPage();
             }
-            int numValues = Math.min(remainingValueCountInPage, nextBatchSize - valueCount);
-            readValues(blockBuilder, numValues, type, positions);
-            valueCount += numValues;
-            updatePosition(numValues);
+            int valuesToRead = Math.min(remainingValueCountInPage, nextBatchSize - valueCount);
+            readValues(blockBuilder, valuesToRead, field.getType(), definitionLevels, repetitionLevels);
+            valueCount += valuesToRead;
         }
         checkArgument(valueCount == nextBatchSize, "valueCount %s not equals to batchSize %s", valueCount, nextBatchSize);
 
         readOffset = 0;
         nextBatchSize = 0;
-        return blockBuilder.build();
+        return new ColumnChunk(blockBuilder.build(), definitionLevels.toIntArray(), repetitionLevels.toIntArray());
     }
 
-    private void readValues(BlockBuilder blockBuilder, int numValues, Type type, IntList positions)
+    private void readValues(BlockBuilder blockBuilder, int valuesToRead, Type type, IntList definitionLevels, IntList repetitionLevels)
     {
-        definitionLevel = definitionReader.readLevel();
-        repetitionLevel = repetitionReader.readLevel();
-        int valueCount = 0;
-        for (int i = 0; i < numValues; i++) {
-            do {
-                readValue(blockBuilder, type);
-                try {
-                    valueCount++;
-                    repetitionLevel = repetitionReader.readLevel();
-                    if (repetitionLevel == 0) {
-                        positions.add(valueCount);
-                        valueCount = 0;
-                        if (i == numValues - 1) {
-                            return;
-                        }
-                    }
-                    definitionLevel = definitionReader.readLevel();
-                }
-                catch (IllegalArgumentException expected) {
-                    // Reading past repetition stream, RunLengthBitPackingHybridDecoder throws IllegalArgumentException
-                    positions.add(valueCount);
-                    return;
-                }
-            }
-            while (repetitionLevel != 0);
+        processValues(valuesToRead, ignored -> {
+            readValue(blockBuilder, type);
+            definitionLevels.add(definitionLevel);
+            repetitionLevels.add(repetitionLevel);
+        });
+    }
+
+    private void skipValues(int valuesToRead)
+    {
+        processValues(valuesToRead, ignored -> skipValue());
+    }
+
+    private void processValues(int valuesToRead, Consumer<Void> valueConsumer)
+    {
+        if (definitionLevel == EMPTY_LEVEL_VALUE && repetitionLevel == EMPTY_LEVEL_VALUE) {
+            definitionLevel = definitionReader.readLevel();
+            repetitionLevel = repetitionReader.readLevel();
         }
-    }
-
-    private void skipValues(int offset)
-    {
-        definitionLevel = definitionReader.readLevel();
-        repetitionLevel = repetitionReader.readLevel();
-        for (int i = 0; i < offset; i++) {
+        int valueCount = 0;
+        for (int i = 0; i < valuesToRead; i++) {
             do {
-                skipValue();
-                try {
-                    repetitionLevel = repetitionReader.readLevel();
-                    if (i == offset - 1 && repetitionLevel == 0) {
+                valueConsumer.accept(null);
+                valueCount++;
+                if (valueCount == remainingValueCountInPage) {
+                    updateValueCounts(valueCount);
+                    if (!readNextPage()) {
                         return;
                     }
-                    definitionLevel = definitionReader.readLevel();
+                    valueCount = 0;
                 }
-                catch (IllegalArgumentException expected) {
-                    // Reading past repetition stream, RunLengthBitPackingHybridDecoder throws IllegalArgumentException
-                    return;
-                }
+                repetitionLevel = repetitionReader.readLevel();
+                definitionLevel = definitionReader.readLevel();
             }
             while (repetitionLevel != 0);
         }
+        updateValueCounts(valueCount);
     }
 
     private void seek()
@@ -237,34 +234,36 @@ public abstract class ParquetColumnReader
             int offset = Math.min(remainingValueCountInPage, readOffset - valuePosition);
             skipValues(offset);
             valuePosition = valuePosition + offset;
-            updatePosition(offset);
         }
         checkArgument(valuePosition == readOffset, "valuePosition %s must be equal to readOffset %s", valuePosition, readOffset);
     }
 
-    private void readNextPage()
-            throws IOException
+    private boolean readNextPage()
     {
+        verify(page == null, "readNextPage has to be called when page is null");
         page = pageReader.readPage();
-        validateParquet(page != null, "Not enough values to read in column chunk");
+        if (page == null) {
+            // we have read all pages
+            return false;
+        }
         remainingValueCountInPage = page.getValueCount();
-
         if (page instanceof ParquetDataPageV1) {
             valuesReader = readPageV1((ParquetDataPageV1) page);
         }
         else {
             valuesReader = readPageV2((ParquetDataPageV2) page);
         }
+        return true;
     }
 
-    private void updatePosition(int numValues)
+    private void updateValueCounts(int valuesRead)
     {
-        if (numValues == remainingValueCountInPage) {
+        if (valuesRead == remainingValueCountInPage) {
             page = null;
             valuesReader = null;
         }
-        remainingValueCountInPage = remainingValueCountInPage - numValues;
-        currentValueCount += numValues;
+        remainingValueCountInPage -= valuesRead;
+        currentValueCount += valuesRead;
     }
 
     private ValuesReader readPageV1(ParquetDataPageV1 page)

--- a/presto-hive/src/main/java/com/facebook/presto/hive/parquet/reader/ParquetReader.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/parquet/reader/ParquetReader.java
@@ -13,38 +13,39 @@
  */
 package com.facebook.presto.hive.parquet.reader;
 
+import com.facebook.presto.hive.parquet.Field;
+import com.facebook.presto.hive.parquet.GroupField;
 import com.facebook.presto.hive.parquet.ParquetCorruptionException;
 import com.facebook.presto.hive.parquet.ParquetDataSource;
+import com.facebook.presto.hive.parquet.PrimitiveField;
 import com.facebook.presto.hive.parquet.RichColumnDescriptor;
 import com.facebook.presto.memory.context.AggregatedMemoryContext;
 import com.facebook.presto.memory.context.LocalMemoryContext;
 import com.facebook.presto.spi.block.ArrayBlock;
 import com.facebook.presto.spi.block.Block;
+import com.facebook.presto.spi.block.MapBlock;
 import com.facebook.presto.spi.block.RowBlock;
 import com.facebook.presto.spi.block.RunLengthEncodedBlock;
 import com.facebook.presto.spi.type.MapType;
-import com.facebook.presto.spi.type.NamedTypeSignature;
 import com.facebook.presto.spi.type.Type;
-import com.facebook.presto.spi.type.TypeManager;
 import com.facebook.presto.spi.type.TypeSignatureParameter;
+import it.unimi.dsi.fastutil.booleans.BooleanArrayList;
+import it.unimi.dsi.fastutil.booleans.BooleanList;
 import it.unimi.dsi.fastutil.ints.IntArrayList;
 import it.unimi.dsi.fastutil.ints.IntList;
 import parquet.column.ColumnDescriptor;
 import parquet.hadoop.metadata.BlockMetaData;
 import parquet.hadoop.metadata.ColumnChunkMetaData;
 import parquet.hadoop.metadata.ColumnPath;
+import parquet.io.MessageColumnIO;
 import parquet.io.PrimitiveColumnIO;
-import parquet.schema.MessageType;
 
 import java.io.Closeable;
 import java.io.IOException;
-import java.util.HashMap;
+import java.util.Arrays;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 
-import static com.facebook.presto.hive.parquet.ParquetTypeUtils.getColumns;
-import static com.facebook.presto.hive.parquet.ParquetTypeUtils.getDescriptor;
 import static com.facebook.presto.hive.parquet.ParquetValidationUtils.validateParquet;
 import static com.facebook.presto.spi.type.StandardTypes.ARRAY;
 import static com.facebook.presto.spi.type.StandardTypes.MAP;
@@ -58,17 +59,9 @@ public class ParquetReader
         implements Closeable
 {
     private static final int MAX_VECTOR_LENGTH = 1024;
-    private static final String MAP_TYPE_NAME = "map";
-    private static final String MAP_KEY_NAME = "key";
-    private static final String MAP_VALUE_NAME = "value";
-    private static final String ARRAY_TYPE_NAME = "bag";
-    private static final String ARRAY_ELEMENT_NAME = "array_element";
 
-    private final MessageType fileSchema;
-    private final MessageType requestedSchema;
     private final List<BlockMetaData> blocks;
     private final ParquetDataSource dataSource;
-    private final TypeManager typeManager;
 
     private int currentBlock;
     private BlockMetaData currentBlockMetadata;
@@ -76,26 +69,23 @@ public class ParquetReader
     private long currentGroupRowCount;
     private long nextRowInGroup;
     private int batchSize;
-    private final Map<ColumnDescriptor, ParquetColumnReader> columnReadersMap = new HashMap<>();
+    private final List<PrimitiveColumnIO> columns;
+    private final ParquetPrimitiveColumnReader[] columnReaders;
 
     private AggregatedMemoryContext currentRowGroupMemoryContext;
     private final AggregatedMemoryContext systemMemoryContext;
 
-    public ParquetReader(MessageType fileSchema,
-            MessageType requestedSchema,
+    public ParquetReader(MessageColumnIO messageColumnIO,
             List<BlockMetaData> blocks,
             ParquetDataSource dataSource,
-            TypeManager typeManager,
             AggregatedMemoryContext systemMemoryContext)
     {
-        this.fileSchema = fileSchema;
-        this.requestedSchema = requestedSchema;
         this.blocks = blocks;
-        this.dataSource = dataSource;
-        this.typeManager = typeManager;
+        this.dataSource = requireNonNull(dataSource, "dataSource is null");
         this.systemMemoryContext = requireNonNull(systemMemoryContext, "systemMemoryContext is null");
         this.currentRowGroupMemoryContext = systemMemoryContext.newAggregatedMemoryContext();
-        initializeColumnReaders();
+        columns = messageColumnIO.getLeaves();
+        columnReaders = new ParquetPrimitiveColumnReader[columns.size()];
     }
 
     @Override
@@ -121,12 +111,7 @@ public class ParquetReader
 
         nextRowInGroup += batchSize;
         currentPosition += batchSize;
-        for (PrimitiveColumnIO columnIO : getColumns(fileSchema, requestedSchema)) {
-            ColumnDescriptor descriptor = columnIO.getColumnDescriptor();
-            RichColumnDescriptor column = new RichColumnDescriptor(descriptor.getPath(), columnIO.getType().asPrimitiveType(), descriptor.getMaxRepetitionLevel(), descriptor.getMaxDefinitionLevel());
-            ParquetColumnReader columnReader = columnReadersMap.get(column);
-            columnReader.prepareNextRead(batchSize);
-        }
+        Arrays.stream(columnReaders).forEach(reader -> reader.prepareNextRead(batchSize));
         return batchSize;
     }
 
@@ -143,113 +128,73 @@ public class ParquetReader
 
         nextRowInGroup = 0L;
         currentGroupRowCount = currentBlockMetadata.getRowCount();
-        columnReadersMap.clear();
         initializeColumnReaders();
         return true;
     }
 
-    public Block readArray(Type type, List<String> path)
+    private ColumnChunk readArray(GroupField field)
             throws IOException
     {
-        return readArray(type, path, new IntArrayList());
-    }
-
-    private Block readArray(Type type, List<String> path, IntList elementOffsets)
-            throws IOException
-    {
-        List<Type> parameters = type.getTypeParameters();
+        List<Type> parameters = field.getType().getTypeParameters();
         checkArgument(parameters.size() == 1, "Arrays must have a single type parameter, found %d", parameters.size());
-        path.add(ARRAY_TYPE_NAME);
-        Type elementType = parameters.get(0);
-        Block block = readBlock(ARRAY_ELEMENT_NAME, elementType, path, elementOffsets);
-        path.remove(ARRAY_TYPE_NAME);
+        Field elementField = field.getChildren().get(0).get();
+        ColumnChunk columnChunk = readColumnChunk(elementField);
+        IntList offsets = new IntArrayList();
+        BooleanList valueIsNull = new BooleanArrayList();
 
-        if (elementOffsets.isEmpty()) {
-            for (int i = 0; i < batchSize; i++) {
-                elementOffsets.add(0);
-            }
-            return RunLengthEncodedBlock.create(elementType, null, batchSize);
-        }
-
-        int[] offsets = new int[batchSize + 1];
-        for (int i = 1; i < offsets.length; i++) {
-            offsets[i] = offsets[i - 1] + elementOffsets.getInt(i - 1);
-        }
-        return new ArrayBlock(batchSize, new boolean[batchSize], offsets, block);
+        ParquetListColumnReader.calculateCollectionOffsets(field, offsets, valueIsNull, columnChunk.getDefinitionLevels(), columnChunk.getRepetitionLevels());
+        ArrayBlock arrayBlock = new ArrayBlock(valueIsNull.size(), valueIsNull.toBooleanArray(), offsets.toIntArray(), columnChunk.getBlock());
+        return new ColumnChunk(arrayBlock, columnChunk.getDefinitionLevels(), columnChunk.getRepetitionLevels());
     }
 
-    public Block readMap(Type type, List<String> path)
+    private ColumnChunk readMap(GroupField field)
             throws IOException
     {
-        return readMap(type, path, new IntArrayList());
-    }
-
-    private Block readMap(Type type, List<String> path, IntList elementOffsets)
-            throws IOException
-    {
-        List<Type> parameters = type.getTypeParameters();
+        List<Type> parameters = field.getType().getTypeParameters();
         checkArgument(parameters.size() == 2, "Maps must have two type parameters, found %d", parameters.size());
         Block[] blocks = new Block[parameters.size()];
 
-        IntList keyOffsets = new IntArrayList();
-        IntList valueOffsets = new IntArrayList();
-        path.add(MAP_TYPE_NAME);
-        blocks[0] = readBlock(MAP_KEY_NAME, parameters.get(0), path, keyOffsets);
-        blocks[1] = readBlock(MAP_VALUE_NAME, parameters.get(1), path, valueOffsets);
-        path.remove(MAP_TYPE_NAME);
+        ColumnChunk columnChunk = readColumnChunk(field.getChildren().get(0).get());
+        blocks[0] = columnChunk.getBlock();
+        blocks[1] = readColumnChunk(field.getChildren().get(1).get()).getBlock();
+        IntList offsets = new IntArrayList();
+        BooleanList valueIsNull = new BooleanArrayList();
+        ParquetListColumnReader.calculateCollectionOffsets(field, offsets, valueIsNull, columnChunk.getDefinitionLevels(), columnChunk.getRepetitionLevels());
+        MapBlock mapBlock = ((MapType) field.getType()).createBlockFromKeyValue(valueIsNull.toBooleanArray(), offsets.toIntArray(), blocks[0], blocks[1]);
+        return new ColumnChunk(mapBlock, columnChunk.getDefinitionLevels(), columnChunk.getRepetitionLevels());
+    }
 
-        if (blocks[0].getPositionCount() == 0) {
-            for (int i = 0; i < batchSize; i++) {
-                elementOffsets.add(0);
+    private ColumnChunk readStruct(GroupField field)
+            throws IOException
+    {
+        List<TypeSignatureParameter> fields = field.getType().getTypeSignature().getParameters();
+        Block[] blocks = new Block[fields.size()];
+        ColumnChunk columnChunk = null;
+        List<Optional<Field>> parameters = field.getChildren();
+        for (int i = 0; i < fields.size(); i++) {
+            Optional<Field> parameter = parameters.get(i);
+            if (parameter.isPresent()) {
+                columnChunk = readColumnChunk(parameter.get());
+                blocks[i] = columnChunk.getBlock();
             }
-            return RunLengthEncodedBlock.create(parameters.get(0), null, batchSize);
         }
-        int[] offsets = new int[batchSize + 1];
-        for (int i = 1; i < offsets.length; i++) {
-            int elementPositionCount = keyOffsets.getInt(i - 1);
-            elementOffsets.add(elementPositionCount * 2);
-            offsets[i] = offsets[i - 1] + elementPositionCount;
+        for (int i = 0; i < fields.size(); i++) {
+            if (blocks[i] == null) {
+                blocks[i] = RunLengthEncodedBlock.create(field.getType(), null, columnChunk.getBlock().getPositionCount());
+            }
         }
-        return ((MapType) type).createBlockFromKeyValue(new boolean[batchSize], offsets, blocks[0], blocks[1]);
+        BooleanList structIsNull = new BooleanArrayList();
+        IntList structOffsets = new IntArrayList();
+        ParquetStructColumnReader.calculateStructOffsets(field, structOffsets, structIsNull, columnChunk.getDefinitionLevels(), columnChunk.getRepetitionLevels());
+        RowBlock rowBlock = new RowBlock(0, structIsNull.size(), structIsNull.toBooleanArray(), structOffsets.toIntArray(), blocks);
+        return new ColumnChunk(rowBlock, columnChunk.getDefinitionLevels(), columnChunk.getRepetitionLevels());
     }
 
-    public Block readStruct(Type type, List<String> path)
+    private ColumnChunk readPrimitive(PrimitiveField field)
             throws IOException
     {
-        return readStruct(type, path, new IntArrayList());
-    }
-
-    private Block readStruct(Type type, List<String> path, IntList elementOffsets)
-            throws IOException
-    {
-        List<TypeSignatureParameter> parameters = type.getTypeSignature().getParameters();
-        Block[] blocks = new Block[parameters.size()];
-        for (int i = 0; i < parameters.size(); i++) {
-            NamedTypeSignature namedTypeSignature = parameters.get(i).getNamedTypeSignature();
-            Type fieldType = typeManager.getType(namedTypeSignature.getTypeSignature());
-            String name = namedTypeSignature.getName();
-            blocks[i] = readBlock(name, fieldType, path, new IntArrayList());
-        }
-
-        int blockSize = blocks[0].getPositionCount();
-        int[] offsets = new int[blockSize + 1];
-        for (int i = 1; i < offsets.length; i++) {
-            elementOffsets.add(parameters.size());
-            offsets[i] = i;
-        }
-        return new RowBlock(0, blockSize, new boolean[blockSize], offsets, blocks);
-    }
-
-    public Block readPrimitive(ColumnDescriptor columnDescriptor, Type type)
-            throws IOException
-    {
-        return readPrimitive(columnDescriptor, type, new IntArrayList());
-    }
-
-    private Block readPrimitive(ColumnDescriptor columnDescriptor, Type type, IntList offsets)
-            throws IOException
-    {
-        ParquetColumnReader columnReader = columnReadersMap.get(columnDescriptor);
+        ColumnDescriptor columnDescriptor = field.getDescriptor();
+        ParquetPrimitiveColumnReader columnReader = columnReaders[field.getId()];
         if (columnReader.getPageReader() == null) {
             validateParquet(currentBlockMetadata.getRowCount() > 0, "Row group has 0 rows");
             ColumnChunkMetaData metadata = getColumnChunkMetaData(columnDescriptor);
@@ -261,7 +206,7 @@ public class ParquetReader
             ParquetColumnChunk columnChunk = new ParquetColumnChunk(descriptor, buffer, 0);
             columnReader.setPageReader(columnChunk.readAllPages());
         }
-        return columnReader.readPrimitive(type, offsets);
+        return columnReader.readPrimitive(field);
     }
 
     private byte[] allocateBlock(int length)
@@ -285,37 +230,44 @@ public class ParquetReader
 
     private void initializeColumnReaders()
     {
-        for (PrimitiveColumnIO columnIO : getColumns(fileSchema, requestedSchema)) {
-            ColumnDescriptor descriptor = columnIO.getColumnDescriptor();
-            RichColumnDescriptor column = new RichColumnDescriptor(descriptor.getPath(), columnIO.getType().asPrimitiveType(), descriptor.getMaxRepetitionLevel(), descriptor.getMaxDefinitionLevel());
-            columnReadersMap.put(column, ParquetColumnReader.createReader(column));
+        for (PrimitiveColumnIO columnIO : columns) {
+            RichColumnDescriptor column = new RichColumnDescriptor(columnIO.getColumnDescriptor(), columnIO.getType().asPrimitiveType());
+            columnReaders[columnIO.getId()] = ParquetPrimitiveColumnReader.createReader(column);
         }
     }
 
-    private Block readBlock(String name, Type type, List<String> path, IntList offsets)
+    public Block readBlock(Field field)
             throws IOException
     {
-        path.add(name);
-        Optional<RichColumnDescriptor> descriptor = getDescriptor(fileSchema, requestedSchema, path);
-        if (!descriptor.isPresent()) {
-            path.remove(name);
-            return RunLengthEncodedBlock.create(type, null, batchSize);
-        }
+        return readColumnChunk(field).getBlock();
+    }
 
-        Block block;
-        if (ROW.equals(type.getTypeSignature().getBase())) {
-            block = readStruct(type, path, offsets);
+    private ColumnChunk readColumnChunk(Field field)
+            throws IOException
+    {
+        ColumnChunk columnChunk;
+        if (ROW.equals(field.getType().getTypeSignature().getBase())) {
+            columnChunk = readStruct((GroupField) field);
         }
-        else if (MAP.equals(type.getTypeSignature().getBase())) {
-            block = readMap(type, path, offsets);
+        else if (MAP.equals(field.getType().getTypeSignature().getBase())) {
+            columnChunk = readMap((GroupField) field);
         }
-        else if (ARRAY.equals(type.getTypeSignature().getBase())) {
-            block = readArray(type, path, offsets);
+        else if (ARRAY.equals(field.getType().getTypeSignature().getBase())) {
+            columnChunk = readArray((GroupField) field);
         }
         else {
-            block = readPrimitive(descriptor.get(), type, offsets);
+            columnChunk = readPrimitive((PrimitiveField) field);
         }
-        path.remove(name);
-        return block;
+        return columnChunk;
+    }
+
+    public ParquetDataSource getDataSource()
+    {
+        return dataSource;
+    }
+
+    public AggregatedMemoryContext getSystemMemoryContext()
+    {
+        return systemMemoryContext;
     }
 }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/parquet/reader/ParquetShortDecimalColumnReader.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/parquet/reader/ParquetShortDecimalColumnReader.java
@@ -13,18 +13,18 @@
  */
 package com.facebook.presto.hive.parquet.reader;
 
+import com.facebook.presto.hive.parquet.RichColumnDescriptor;
 import com.facebook.presto.spi.block.BlockBuilder;
 import com.facebook.presto.spi.type.Type;
-import parquet.column.ColumnDescriptor;
 
 import static com.facebook.presto.hive.util.DecimalUtils.getShortDecimalValue;
 import static parquet.schema.PrimitiveType.PrimitiveTypeName.INT32;
 import static parquet.schema.PrimitiveType.PrimitiveTypeName.INT64;
 
 public class ParquetShortDecimalColumnReader
-        extends ParquetColumnReader
+        extends ParquetPrimitiveColumnReader
 {
-    ParquetShortDecimalColumnReader(ColumnDescriptor descriptor)
+    ParquetShortDecimalColumnReader(RichColumnDescriptor descriptor)
     {
         super(descriptor);
     }
@@ -46,7 +46,7 @@ public class ParquetShortDecimalColumnReader
             }
             type.writeLong(blockBuilder, decimalValue);
         }
-        else {
+        else if (isValueNull()) {
             blockBuilder.appendNull();
         }
     }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/parquet/reader/ParquetStructColumnReader.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/parquet/reader/ParquetStructColumnReader.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.hive.parquet.reader;
+
+import com.facebook.presto.hive.parquet.Field;
+import it.unimi.dsi.fastutil.booleans.BooleanList;
+import it.unimi.dsi.fastutil.ints.IntList;
+
+import static com.facebook.presto.hive.parquet.ParquetTypeUtils.isValueNull;
+
+public class ParquetStructColumnReader
+{
+    private ParquetStructColumnReader()
+    {
+    }
+
+    /**
+     * Each struct has three variants of presence:
+     * 1) Struct is not defined, because one of it's optional parent fields is null
+     * 2) Struct is null
+     * 3) Struct is defined and not empty. In this case offset value is increased by one.
+     * <p>
+     * One of the struct's field repetition/definition levels are used to calculate offsets of the struct.
+     */
+    public static void calculateStructOffsets(
+            Field field,
+            IntList structOffsets,
+            BooleanList structIsNull,
+            int[] fieldDefinitionLevels,
+            int[] fieldRepetitionLevels)
+    {
+        int maxDefinitionLevel = field.getDefinitionLevel();
+        int maxRepetitionLevel = field.getRepetitionLevel();
+        boolean required = field.isRequired();
+        int offset = 0;
+        structOffsets.add(offset);
+        if (fieldDefinitionLevels == null) {
+            return;
+        }
+        for (int i = 0; i < fieldDefinitionLevels.length; i++) {
+            if (fieldRepetitionLevels[i] <= maxRepetitionLevel) {
+                if (isValueNull(required, fieldDefinitionLevels[i], maxDefinitionLevel)) {
+                    // Struct is null
+                    structIsNull.add(true);
+                    structOffsets.add(offset);
+                }
+                else if (fieldDefinitionLevels[i] >= maxDefinitionLevel) {
+                    // Struct is defined and not empty
+                    structIsNull.add(false);
+                    offset++;
+                    structOffsets.add(offset);
+                }
+            }
+        }
+    }
+}

--- a/presto-hive/src/main/java/com/facebook/presto/hive/parquet/reader/ParquetTimestampColumnReader.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/parquet/reader/ParquetTimestampColumnReader.java
@@ -13,17 +13,17 @@
  */
 package com.facebook.presto.hive.parquet.reader;
 
+import com.facebook.presto.hive.parquet.RichColumnDescriptor;
 import com.facebook.presto.spi.block.BlockBuilder;
 import com.facebook.presto.spi.type.Type;
-import parquet.column.ColumnDescriptor;
 import parquet.io.api.Binary;
 
 import static com.facebook.presto.hive.parquet.ParquetTimestampUtils.getTimestampMillis;
 
 public class ParquetTimestampColumnReader
-        extends ParquetColumnReader
+        extends ParquetPrimitiveColumnReader
 {
-    public ParquetTimestampColumnReader(ColumnDescriptor descriptor)
+    public ParquetTimestampColumnReader(RichColumnDescriptor descriptor)
     {
         super(descriptor);
     }
@@ -35,7 +35,7 @@ public class ParquetTimestampColumnReader
             Binary binary = valuesReader.readBytes();
             type.writeLong(blockBuilder, getTimestampMillis(binary));
         }
-        else {
+        else if (isValueNull()) {
             blockBuilder.appendNull();
         }
     }

--- a/presto-hive/src/main/java/parquet/io/ColumnIOConverter.java
+++ b/presto-hive/src/main/java/parquet/io/ColumnIOConverter.java
@@ -1,0 +1,97 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package parquet.io;
+
+import com.facebook.presto.hive.parquet.Field;
+import com.facebook.presto.hive.parquet.GroupField;
+import com.facebook.presto.hive.parquet.PrimitiveField;
+import com.facebook.presto.hive.parquet.RichColumnDescriptor;
+import com.facebook.presto.spi.type.MapType;
+import com.facebook.presto.spi.type.NamedTypeSignature;
+import com.facebook.presto.spi.type.Type;
+import com.facebook.presto.spi.type.TypeSignatureParameter;
+import com.google.common.collect.ImmutableList;
+
+import java.util.List;
+import java.util.Locale;
+import java.util.Optional;
+
+import static com.facebook.presto.hive.parquet.ParquetTypeUtils.getArrayElementColumn;
+import static com.facebook.presto.hive.parquet.ParquetTypeUtils.getMapKeyValueColumn;
+import static com.facebook.presto.spi.type.StandardTypes.ARRAY;
+import static com.facebook.presto.spi.type.StandardTypes.MAP;
+import static com.facebook.presto.spi.type.StandardTypes.ROW;
+
+/**
+ * Placed in parquet.io package to have access to ColumnIO getRepetitionLevel() and getDefinitionLevel() methods.
+ */
+public class ColumnIOConverter
+{
+    private ColumnIOConverter()
+    {
+    }
+
+    public static Optional<Field> constructField(Type type, ColumnIO columnIO)
+    {
+        if (columnIO == null) {
+            return Optional.empty();
+        }
+        boolean required = columnIO.getType().getRepetition() != parquet.schema.Type.Repetition.OPTIONAL;
+        int repetitionLevel = columnIO.getRepetitionLevel();
+        int definitionLevel = columnIO.getDefinitionLevel();
+        if (ROW.equals(type.getTypeSignature().getBase())) {
+            GroupColumnIO groupColumnIO = (GroupColumnIO) columnIO;
+            List<Type> parameters = type.getTypeParameters();
+            ImmutableList.Builder<Optional<Field>> fileldsBuilder = ImmutableList.builder();
+            List<TypeSignatureParameter> fields = type.getTypeSignature().getParameters();
+            boolean structHasParameters = false;
+            for (int i = 0; i < fields.size(); i++) {
+                NamedTypeSignature namedTypeSignature = fields.get(i).getNamedTypeSignature();
+                String name = namedTypeSignature.getName().toLowerCase(Locale.ENGLISH);
+                Optional<Field> field = constructField(parameters.get(i), groupColumnIO.getChild(name));
+                structHasParameters |= field.isPresent();
+                fileldsBuilder.add(field);
+            }
+            if (structHasParameters) {
+                return Optional.of(new GroupField(type, repetitionLevel, definitionLevel, required, fileldsBuilder.build()));
+            }
+            else {
+                return Optional.empty();
+            }
+        }
+        else if (MAP.equals(type.getTypeSignature().getBase())) {
+            GroupColumnIO groupColumnIO = (GroupColumnIO) columnIO;
+            MapType mapType = (MapType) type;
+            GroupColumnIO keyValueColumnIO = getMapKeyValueColumn(groupColumnIO);
+            if (keyValueColumnIO.getChildrenCount() < 2) {
+                return Optional.empty();
+            }
+            Optional<Field> keyField = constructField(mapType.getKeyType(), keyValueColumnIO.getChild(0));
+            Optional<Field> valueField = constructField(mapType.getValueType(), keyValueColumnIO.getChild(1));
+            return Optional.of(new GroupField(type, repetitionLevel, definitionLevel, required, ImmutableList.of(keyField, valueField)));
+        }
+        else if (ARRAY.equals(type.getTypeSignature().getBase())) {
+            GroupColumnIO groupColumnIO = (GroupColumnIO) columnIO;
+            List<Type> types = type.getTypeParameters();
+            if (groupColumnIO.getChildrenCount() == 0) {
+                return Optional.empty();
+            }
+            Optional<Field> field = constructField(types.get(0), getArrayElementColumn(groupColumnIO.getChild(0)));
+            return Optional.of(new GroupField(type, repetitionLevel, definitionLevel, required, ImmutableList.of(field)));
+        }
+        PrimitiveColumnIO primitiveColumnIO = (PrimitiveColumnIO) columnIO;
+        RichColumnDescriptor column = new RichColumnDescriptor(primitiveColumnIO.getColumnDescriptor(), columnIO.getType().asPrimitiveType());
+        return Optional.of(new PrimitiveField(type, repetitionLevel, definitionLevel, required, column, primitiveColumnIO.getId()));
+    }
+}

--- a/presto-hive/src/main/java/parquet/io/ColumnIOConverter.java
+++ b/presto-hive/src/main/java/parquet/io/ColumnIOConverter.java
@@ -59,7 +59,7 @@ public class ColumnIOConverter
             for (int i = 0; i < fields.size(); i++) {
                 NamedTypeSignature namedTypeSignature = fields.get(i).getNamedTypeSignature();
                 String name = namedTypeSignature.getName().toLowerCase(Locale.ENGLISH);
-                Optional<Field> field = constructField(parameters.get(i), groupColumnIO.getChild(name));
+                Optional<Field> field = constructField(parameters.get(i), findColumnIObyName(groupColumnIO, name));
                 structHasParameters |= field.isPresent();
                 fileldsBuilder.add(field);
             }
@@ -93,5 +93,16 @@ public class ColumnIOConverter
         PrimitiveColumnIO primitiveColumnIO = (PrimitiveColumnIO) columnIO;
         RichColumnDescriptor column = new RichColumnDescriptor(primitiveColumnIO.getColumnDescriptor(), columnIO.getType().asPrimitiveType());
         return Optional.of(new PrimitiveField(type, repetitionLevel, definitionLevel, required, column, primitiveColumnIO.getId()));
+    }
+
+    public static ColumnIO findColumnIObyName(GroupColumnIO groupColumnIO, String name)
+    {
+        ColumnIO columnIO = groupColumnIO.getChild(name);
+
+        if (columnIO == null && name.endsWith("_")) {
+            return findColumnIObyName(groupColumnIO, name.substring(0, name.length() - 1));
+        }
+
+        return columnIO;
     }
 }

--- a/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveFileFormats.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveFileFormats.java
@@ -614,6 +614,56 @@ public abstract class AbstractTestHiveFileFormats
         return HiveStorageFormat.class.getClassLoader().loadClass(className).asSubclass(superType).newInstance();
     }
 
+    public static Object getFieldFromCursor(RecordCursor cursor, Type type, int field)
+    {
+        if (cursor.isNull(field)) {
+            return null;
+        }
+        else if (BOOLEAN.equals(type)) {
+            return cursor.getBoolean(field);
+        }
+        else if (TINYINT.equals(type)) {
+            return cursor.getLong(field);
+        }
+        else if (SMALLINT.equals(type)) {
+            return cursor.getLong(field);
+        }
+        else if (INTEGER.equals(type)) {
+            return (int) cursor.getLong(field);
+        }
+        else if (BIGINT.equals(type)) {
+            return cursor.getLong(field);
+        }
+        else if (REAL.equals(type)) {
+            return intBitsToFloat((int) cursor.getLong(field));
+        }
+        else if (DOUBLE.equals(type)) {
+            return cursor.getDouble(field);
+        }
+        else if (isVarcharType(type) || isCharType(type) || VARBINARY.equals(type)) {
+            return cursor.getSlice(field);
+        }
+        else if (DateType.DATE.equals(type)) {
+            return cursor.getLong(field);
+        }
+        else if (TimestampType.TIMESTAMP.equals(type)) {
+            return cursor.getLong(field);
+        }
+        else if (isStructuralType(type)) {
+            return cursor.getObject(field);
+        }
+        else if (type instanceof DecimalType) {
+            DecimalType decimalType = (DecimalType) type;
+            if (decimalType.isShort()) {
+                return BigInteger.valueOf(cursor.getLong(field));
+            }
+            else {
+                return Decimals.decodeUnscaledValue(cursor.getSlice(field));
+            }
+        }
+        throw new RuntimeException("unknown type");
+    }
+
     protected void checkCursor(RecordCursor cursor, List<TestColumn> testColumns, int rowCount)
     {
         for (int row = 0; row < rowCount; row++) {
@@ -621,69 +671,18 @@ public abstract class AbstractTestHiveFileFormats
             for (int i = 0, testColumnsSize = testColumns.size(); i < testColumnsSize; i++) {
                 TestColumn testColumn = testColumns.get(i);
 
-                Object fieldFromCursor;
                 Type type = HiveType.valueOf(testColumn.getObjectInspector().getTypeName()).getType(TYPE_MANAGER);
-                if (cursor.isNull(i)) {
-                    fieldFromCursor = null;
-                }
-                else if (BOOLEAN.equals(type)) {
-                    fieldFromCursor = cursor.getBoolean(i);
-                }
-                else if (TINYINT.equals(type)) {
-                    fieldFromCursor = cursor.getLong(i);
-                }
-                else if (SMALLINT.equals(type)) {
-                    fieldFromCursor = cursor.getLong(i);
-                }
-                else if (INTEGER.equals(type)) {
-                    fieldFromCursor = cursor.getLong(i);
-                }
-                else if (BIGINT.equals(type)) {
-                    fieldFromCursor = cursor.getLong(i);
-                }
-                else if (REAL.equals(type)) {
-                    fieldFromCursor = cursor.getLong(i);
-                }
-                else if (DOUBLE.equals(type)) {
-                    fieldFromCursor = cursor.getDouble(i);
-                }
-                else if (isVarcharType(type)) {
-                    fieldFromCursor = cursor.getSlice(i);
-                }
-                else if (isCharType(type)) {
-                    fieldFromCursor = cursor.getSlice(i);
-                }
-                else if (VARBINARY.equals(type)) {
-                    fieldFromCursor = cursor.getSlice(i);
-                }
-                else if (DateType.DATE.equals(type)) {
-                    fieldFromCursor = cursor.getLong(i);
-                }
-                else if (TimestampType.TIMESTAMP.equals(type)) {
-                    fieldFromCursor = cursor.getLong(i);
-                }
-                else if (isStructuralType(type)) {
-                    fieldFromCursor = cursor.getObject(i);
-                }
-                else if (type instanceof DecimalType) {
-                    DecimalType decimalType = (DecimalType) type;
-                    if (decimalType.isShort()) {
-                        fieldFromCursor = new BigDecimal(BigInteger.valueOf(cursor.getLong(i)), decimalType.getScale());
-                    }
-                    else {
-                        fieldFromCursor = new BigDecimal(Decimals.decodeUnscaledValue(cursor.getSlice(i)), decimalType.getScale());
-                    }
-                }
-                else {
-                    throw new RuntimeException("unknown type");
-                }
-
+                Object fieldFromCursor = getFieldFromCursor(cursor, type, i);
                 if (fieldFromCursor == null) {
                     assertEquals(null, testColumn.getExpectedValue(), String.format("Expected null for column %s", testColumn.getName()));
                 }
+                else if (type instanceof DecimalType) {
+                    DecimalType decimalType = (DecimalType) type;
+                    fieldFromCursor = new BigDecimal((BigInteger) fieldFromCursor, decimalType.getScale());
+                    assertEquals(fieldFromCursor, testColumn.getExpectedValue(), String.format("Wrong value for column %s", testColumn.getName()));
+                }
                 else if (testColumn.getObjectInspector().getTypeName().equals("float")) {
-                    int intBits = (int) ((long) fieldFromCursor);
-                    assertEquals(intBitsToFloat(intBits), (float) testColumn.getExpectedValue(), (float) EPSILON);
+                    assertEquals((float) fieldFromCursor, (float) testColumn.getExpectedValue(), (float) EPSILON);
                 }
                 else if (testColumn.getObjectInspector().getTypeName().equals("double")) {
                     assertEquals((double) fieldFromCursor, (double) testColumn.getExpectedValue(), EPSILON);

--- a/presto-hive/src/test/java/com/facebook/presto/hive/parquet/AbstractTestParquetReader.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/parquet/AbstractTestParquetReader.java
@@ -13,10 +13,13 @@
  */
 package com.facebook.presto.hive.parquet;
 
+import com.facebook.presto.spi.type.ArrayType;
+import com.facebook.presto.spi.type.RowType;
 import com.facebook.presto.spi.type.SqlDate;
 import com.facebook.presto.spi.type.SqlDecimal;
 import com.facebook.presto.spi.type.SqlTimestamp;
 import com.facebook.presto.spi.type.SqlVarbinary;
+import com.facebook.presto.spi.type.Type;
 import com.google.common.collect.AbstractIterator;
 import com.google.common.collect.AbstractSequentialIterator;
 import com.google.common.collect.ContiguousSet;
@@ -25,6 +28,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Range;
 import com.google.common.primitives.Shorts;
 import org.apache.hadoop.hive.common.type.HiveDecimal;
+import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector;
 import org.apache.hadoop.hive.serde2.objectinspector.primitive.JavaHiveDecimalObjectInspector;
 import org.apache.hadoop.hive.serde2.typeinfo.DecimalTypeInfo;
 import org.joda.time.DateTimeZone;
@@ -39,17 +43,24 @@ import java.math.BigInteger;
 import java.sql.Date;
 import java.sql.Timestamp;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Random;
+import java.util.UUID;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static com.facebook.presto.hive.parquet.ParquetTester.HIVE_STORAGE_TIME_ZONE;
+import static com.facebook.presto.hive.parquet.ParquetTester.insertNullEvery;
 import static com.facebook.presto.spi.type.BigintType.BIGINT;
 import static com.facebook.presto.spi.type.BooleanType.BOOLEAN;
 import static com.facebook.presto.spi.type.DateType.DATE;
@@ -61,14 +72,21 @@ import static com.facebook.presto.spi.type.RealType.REAL;
 import static com.facebook.presto.spi.type.TimeZoneKey.UTC_KEY;
 import static com.facebook.presto.spi.type.TimestampType.TIMESTAMP;
 import static com.facebook.presto.spi.type.VarbinaryType.VARBINARY;
+import static com.facebook.presto.spi.type.VarcharType.VARCHAR;
 import static com.facebook.presto.spi.type.VarcharType.createUnboundedVarcharType;
+import static com.facebook.presto.tests.StructuralTestUtil.mapType;
 import static com.google.common.base.Functions.compose;
+import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.collect.Iterables.concat;
 import static com.google.common.collect.Iterables.cycle;
 import static com.google.common.collect.Iterables.limit;
 import static com.google.common.collect.Iterables.transform;
 import static java.lang.String.format;
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.Collections.singletonList;
+import static org.apache.hadoop.hive.serde2.objectinspector.ObjectInspectorFactory.getStandardListObjectInspector;
+import static org.apache.hadoop.hive.serde2.objectinspector.ObjectInspectorFactory.getStandardMapObjectInspector;
+import static org.apache.hadoop.hive.serde2.objectinspector.ObjectInspectorFactory.getStandardStructObjectInspector;
 import static org.apache.hadoop.hive.serde2.objectinspector.primitive.PrimitiveObjectInspectorFactory.javaBooleanObjectInspector;
 import static org.apache.hadoop.hive.serde2.objectinspector.primitive.PrimitiveObjectInspectorFactory.javaByteArrayObjectInspector;
 import static org.apache.hadoop.hive.serde2.objectinspector.primitive.PrimitiveObjectInspectorFactory.javaByteObjectInspector;
@@ -100,6 +118,602 @@ public abstract class AbstractTestParquetReader
     {
         assertEquals(DateTimeZone.getDefault(), HIVE_STORAGE_TIME_ZONE);
         setParquetLogging();
+    }
+
+    @Test
+    public void testArray()
+            throws Exception
+    {
+        Iterable<List<Integer>> values = createTestArrays(limit(cycle(Arrays.asList(1, null, 3, 5, null, null, null, 7, 11, null, 13, 17)), 30_000));
+        tester.testRoundTrip(getStandardListObjectInspector(javaIntObjectInspector), values, values, new ArrayType(INTEGER));
+    }
+
+    @Test
+    public void testEmptyArrays()
+            throws Exception
+    {
+        Iterable<List<Integer>> values = limit(cycle(singletonList(Collections.emptyList())), 30_000);
+        tester.testRoundTrip(getStandardListObjectInspector(javaIntObjectInspector), values, values, new ArrayType(INTEGER));
+    }
+
+    @Test
+    public void testNestedArrays()
+            throws Exception
+    {
+        int nestingLevel = ThreadLocalRandom.current().nextInt(1, 15);
+        ObjectInspector objectInspector = getStandardListObjectInspector(javaIntObjectInspector);
+        Type type = new ArrayType(INTEGER);
+        Iterable values = limit(cycle(Arrays.asList(1, null, 3, null, 5, null, 7, null, null, null, 11, null, 13)), 3_210);
+        for (int i = 0; i < nestingLevel; i++) {
+            values = createNullableTestArrays(values);
+            objectInspector = getStandardListObjectInspector(objectInspector);
+            type = new ArrayType(type);
+        }
+        values = createTestArrays(values);
+        tester.testRoundTrip(objectInspector, values, values, type);
+    }
+
+    @Test
+    public void testSingleLevelSchemaNestedArrays()
+            throws Exception
+    {
+        int nestingLevel = ThreadLocalRandom.current().nextInt(1, 15);
+        ObjectInspector objectInspector = getStandardListObjectInspector(javaIntObjectInspector);
+        Type type = new ArrayType(INTEGER);
+        Iterable values = intsBetween(0, 31_234);
+        for (int i = 0; i < nestingLevel; i++) {
+            values = createTestArrays(values);
+            objectInspector = getStandardListObjectInspector(objectInspector);
+            type = new ArrayType(type);
+        }
+        values = createTestArrays(values);
+        tester.testSingleLevelArraySchemaRoundTrip(objectInspector, values, values, type);
+    }
+
+    @Test
+    public void testArrayOfStructs()
+            throws Exception
+    {
+        Iterable<List> structs = createNullableTestStructs(transform(intsBetween(0, 31_234), Object::toString), longsBetween(0, 31_234));
+        Iterable<List<List>> values = createTestArrays(structs);
+        List<String> structFieldNames = Arrays.asList("stringField", "longField");
+        Type structType = new RowType(ImmutableList.of(VARCHAR, BIGINT), Optional.of(structFieldNames));
+        tester.testRoundTrip(
+                getStandardListObjectInspector(getStandardStructObjectInspector(structFieldNames, Arrays.asList(javaStringObjectInspector, javaLongObjectInspector))),
+                values, values, new ArrayType(structType));
+    }
+
+    @Test
+    public void testCustomSchemaArrayOfStucts()
+            throws Exception
+    {
+        MessageType customSchemaArrayOfStucts = parseMessageType("message ParquetSchema { " +
+                "  optional group self (LIST) { " +
+                "    repeated group self_tuple { " +
+                "      optional int64 a; " +
+                "      optional boolean b; " +
+                "      required binary c (UTF8); " +
+                "    } " +
+                "  } " +
+                "}");
+        Iterable<Long> aValues = limit(cycle(Arrays.asList(1L, null, 3L, 5L, null, null, null, 7L, 11L, null, 13L, 17L)), 30_000);
+        Iterable<Boolean> bValues = limit(cycle(Arrays.asList(null, true, false, null, null, true, false)), 30_000);
+        Iterable<String> cValues = transform(intsBetween(0, 31_234), Object::toString);
+
+        Iterable<List> structs = createTestStructs(aValues, bValues, cValues);
+        Iterable<List<List>> values = createTestArrays(structs);
+        List<String> structFieldNames = Arrays.asList("a", "b", "c");
+        Type structType = new RowType(ImmutableList.of(BIGINT, BOOLEAN, VARCHAR), Optional.of(structFieldNames));
+        tester.testRoundTrip(
+                getStandardListObjectInspector(getStandardStructObjectInspector(structFieldNames, Arrays.asList(javaLongObjectInspector, javaBooleanObjectInspector, javaStringObjectInspector))),
+                values, values, new ArrayType(structType), Optional.of(customSchemaArrayOfStucts));
+    }
+
+    @Test
+    public void testSingleLevelSchemaArrayOfStucts()
+            throws Exception
+    {
+        Iterable<Long> aValues = limit(cycle(Arrays.asList(1L, null, 3L, 5L, null, null, null, 7L, 11L, null, 13L, 17L)), 30_000);
+        Iterable<Boolean> bValues = limit(cycle(Arrays.asList(null, true, false, null, null, true, false)), 30_000);
+        Iterable<String> cValues = transform(intsBetween(0, 31_234), Object::toString);
+
+        Iterable<List> structs = createTestStructs(aValues, bValues, cValues);
+        Iterable<List<List>> values = createTestArrays(structs);
+        List<String> structFieldNames = Arrays.asList("a", "b", "c");
+        Type structType = new RowType(ImmutableList.of(BIGINT, BOOLEAN, VARCHAR), Optional.of(structFieldNames));
+        ObjectInspector objectInspector = getStandardListObjectInspector(getStandardStructObjectInspector(structFieldNames, Arrays.asList(javaLongObjectInspector, javaBooleanObjectInspector, javaStringObjectInspector)));
+        tester.testSingleLevelArraySchemaRoundTrip(objectInspector, values, values, new ArrayType(structType));
+    }
+
+    @Test
+    public void testArrayOfArrayOfStructOfArray()
+            throws Exception
+    {
+        Iterable<List<String>> stringArrayField = createNullableTestArrays(transform(intsBetween(0, 31_234), Object::toString));
+        Iterable<List> structs = createNullableTestStructs(stringArrayField, limit(cycle(Arrays.asList(1, null, 3, 5, null, 7, 11, null, 17)), 31_234));
+        List<String> structFieldNames = Arrays.asList("stringArrayField", "intField");
+        Type structType = new RowType(ImmutableList.of(new ArrayType(VARCHAR), INTEGER), Optional.of(structFieldNames));
+        Iterable<List<List>> arrays = createNullableTestArrays(structs);
+        Iterable<List<List<List>>> values = createTestArrays(arrays);
+        tester.testRoundTrip(
+                getStandardListObjectInspector(
+                        getStandardListObjectInspector(
+                                getStandardStructObjectInspector(
+                                        structFieldNames,
+                                        Arrays.asList(getStandardListObjectInspector(javaStringObjectInspector), javaIntObjectInspector)))),
+                values, values, new ArrayType(new ArrayType(structType)));
+    }
+
+    @Test
+    public void testSingleLevelSchemaArrayOfArrayOfStructOfArray()
+            throws Exception
+    {
+        Iterable<List<String>> stringArrayField = createNullableTestArrays(transform(intsBetween(0, 31_234), Object::toString));
+        Iterable<List> structs = createTestStructs(stringArrayField, limit(cycle(Arrays.asList(1, null, 3, 5, null, 7, 11, null, 17)), 31_234));
+        List<String> structFieldNames = Arrays.asList("stringArrayField", "intField");
+        Type structType = new RowType(ImmutableList.of(new ArrayType(VARCHAR), INTEGER), Optional.of(structFieldNames));
+        Iterable<List<List>> arrays = createTestArrays(structs);
+        Iterable<List<List<List>>> values = createTestArrays(arrays);
+        tester.testSingleLevelArraySchemaRoundTrip(
+                getStandardListObjectInspector(
+                        getStandardListObjectInspector(
+                                getStandardStructObjectInspector(
+                                        structFieldNames,
+                                        Arrays.asList(getStandardListObjectInspector(javaStringObjectInspector), javaIntObjectInspector)))),
+                values, values, new ArrayType(new ArrayType(structType)));
+    }
+
+    @Test
+    public void testArrayOfStructOfArray()
+            throws Exception
+    {
+        Iterable<List<String>> stringArrayField = createNullableTestArrays(transform(intsBetween(0, 31_234), Object::toString));
+        Iterable<List> structs = createNullableTestStructs(stringArrayField, limit(cycle(Arrays.asList(1, 3, null, 5, 7, null, 11, 13, null, 17)), 31_234));
+        List<String> structFieldNames = Arrays.asList("stringArrayField", "intField");
+        Type structType = new RowType(ImmutableList.of(new ArrayType(VARCHAR), INTEGER), Optional.of(structFieldNames));
+        Iterable<List<List>> values = createTestArrays(structs);
+        tester.testRoundTrip(
+                getStandardListObjectInspector(
+                        getStandardStructObjectInspector(
+                                structFieldNames,
+                                Arrays.asList(getStandardListObjectInspector(javaStringObjectInspector), javaIntObjectInspector))),
+                values, values, new ArrayType(structType));
+    }
+
+    @Test
+    public void testSingleLevelSchemaArrayOfStructOfArray()
+            throws Exception
+    {
+        Iterable<List<String>> stringArrayField = createNullableTestArrays(transform(intsBetween(0, 31_234), Object::toString));
+        Iterable<List> structs = createTestStructs(stringArrayField, limit(cycle(Arrays.asList(1, 3, null, 5, 7, null, 11, 13, null, 17)), 31_234));
+        List<String> structFieldNames = Arrays.asList("stringArrayField", "intField");
+        Type structType = new RowType(ImmutableList.of(new ArrayType(VARCHAR), INTEGER), Optional.of(structFieldNames));
+        Iterable<List<List>> values = createTestArrays(structs);
+        tester.testSingleLevelArraySchemaRoundTrip(
+                getStandardListObjectInspector(
+                        getStandardStructObjectInspector(
+                                structFieldNames,
+                                Arrays.asList(getStandardListObjectInspector(javaStringObjectInspector), javaIntObjectInspector))),
+                values, values, new ArrayType(structType));
+    }
+
+    @Test
+    public void testMap()
+            throws Exception
+    {
+        Iterable<Map<String, Long>> values = createTestMaps(transform(intsBetween(0, 100_000), Object::toString), longsBetween(0, 10_000));
+        tester.testRoundTrip(getStandardMapObjectInspector(javaStringObjectInspector, javaLongObjectInspector), values, values, mapType(VARCHAR, BIGINT));
+    }
+
+    @Test
+    public void testNestedMaps()
+            throws Exception
+    {
+        int nestingLevel = ThreadLocalRandom.current().nextInt(1, 15);
+        Iterable<Integer> keys = intsBetween(0, 3_210);
+        Iterable maps = limit(cycle(Arrays.asList(null, "value2", "value3", null, null, "value6", "value7")), 3_210);
+        ObjectInspector objectInspector = getStandardMapObjectInspector(javaIntObjectInspector, javaStringObjectInspector);
+        Type type = mapType(INTEGER, VARCHAR);
+        for (int i = 0; i < nestingLevel; i++) {
+            maps = createNullableTestMaps(keys, maps);
+            objectInspector = getStandardMapObjectInspector(javaIntObjectInspector, objectInspector);
+            type = mapType(INTEGER, type);
+        }
+        maps = createTestMaps(keys, maps);
+        tester.testRoundTrip(objectInspector, maps, maps, type);
+    }
+
+    @Test
+    public void testArrayOfMaps()
+            throws Exception
+    {
+        Iterable<Map<String, Long>> maps = createNullableTestMaps(transform(intsBetween(0, 10), Object::toString), longsBetween(0, 10));
+        List<List<Map<String, Long>>> values = createTestArrays(maps);
+        tester.testRoundTrip(getStandardListObjectInspector(getStandardMapObjectInspector(javaStringObjectInspector, javaLongObjectInspector)),
+                values, values, new ArrayType(mapType(VARCHAR, BIGINT)));
+    }
+
+    @Test
+    public void testSingleLevelSchemaArrayOfMaps()
+            throws Exception
+    {
+        Iterable<Map<String, Long>> maps = createTestMaps(transform(intsBetween(0, 10), Object::toString), longsBetween(0, 10));
+        List<List<Map<String, Long>>> values = createTestArrays(maps);
+        ObjectInspector objectInspector = getStandardListObjectInspector(getStandardMapObjectInspector(javaStringObjectInspector, javaLongObjectInspector));
+        tester.testSingleLevelArraySchemaRoundTrip(objectInspector, values, values, new ArrayType(mapType(VARCHAR, BIGINT)));
+    }
+
+    @Test
+    public void testArrayOfMapOfStruct()
+            throws Exception
+    {
+        Iterable<Integer> keys = intsBetween(0, 10_000);
+        Iterable<List> structs = createNullableTestStructs(transform(intsBetween(0, 10_000), Object::toString), longsBetween(0, 10_000));
+        List<String> structFieldNames = Arrays.asList("stringField", "longField");
+        Type structType = new RowType(ImmutableList.of(VARCHAR, BIGINT), Optional.of(structFieldNames));
+        Iterable<Map<Integer, List>> maps = createNullableTestMaps(keys, structs);
+        List<List<Map<Integer, List>>> values = createTestArrays(maps);
+        tester.testRoundTrip(getStandardListObjectInspector(
+                getStandardMapObjectInspector(
+                        javaIntObjectInspector,
+                        getStandardStructObjectInspector(structFieldNames, Arrays.asList(javaStringObjectInspector, javaLongObjectInspector)))),
+                values, values, new ArrayType(mapType(INTEGER, structType)));
+    }
+
+    @Test
+    public void testSingleLevelArrayOfMapOfStruct()
+            throws Exception
+    {
+        Iterable<Integer> keys = intsBetween(0, 10_000);
+        Iterable<List> structs = createNullableTestStructs(transform(intsBetween(0, 10_000), Object::toString), longsBetween(0, 10_000));
+        List<String> structFieldNames = Arrays.asList("stringField", "longField");
+        Type structType = new RowType(ImmutableList.of(VARCHAR, BIGINT), Optional.of(structFieldNames));
+        Iterable<Map<Integer, List>> maps = createTestMaps(keys, structs);
+        List<List<Map<Integer, List>>> values = createTestArrays(maps);
+        tester.testSingleLevelArraySchemaRoundTrip(getStandardListObjectInspector(
+                getStandardMapObjectInspector(
+                        javaIntObjectInspector,
+                        getStandardStructObjectInspector(structFieldNames, Arrays.asList(javaStringObjectInspector, javaLongObjectInspector)))),
+                values, values, new ArrayType(mapType(INTEGER, structType)));
+    }
+
+    @Test
+    public void testArrayOfMapOfArray()
+            throws Exception
+    {
+        Iterable<List<Integer>> arrays = createNullableTestArrays(limit(cycle(Arrays.asList(1, null, 3, 5, null, null, null, 7, 11, null, 13, 17)), 10_000));
+        Iterable<String> keys = transform(intsBetween(0, 10_000), Object::toString);
+        Iterable<Map<String, List<Integer>>> maps = createNullableTestMaps(keys, arrays);
+        List<List<Map<String, List<Integer>>>> values = createTestArrays(maps);
+        tester.testRoundTrip(getStandardListObjectInspector(
+                getStandardMapObjectInspector(
+                        javaStringObjectInspector,
+                        getStandardListObjectInspector(javaIntObjectInspector))),
+                values, values, new ArrayType(mapType(VARCHAR, new ArrayType(INTEGER))));
+    }
+
+    @Test
+    public void testSingleLevelArrayOfMapOfArray()
+            throws Exception
+    {
+        Iterable<List<Integer>> arrays = createNullableTestArrays(intsBetween(0, 10_000));
+        Iterable<String> keys = transform(intsBetween(0, 10_000), Object::toString);
+        Iterable<Map<String, List<Integer>>> maps = createTestMaps(keys, arrays);
+        List<List<Map<String, List<Integer>>>> values = createTestArrays(maps);
+        tester.testSingleLevelArraySchemaRoundTrip(getStandardListObjectInspector(
+                getStandardMapObjectInspector(
+                        javaStringObjectInspector,
+                        getStandardListObjectInspector(javaIntObjectInspector))),
+                values, values, new ArrayType(mapType(VARCHAR, new ArrayType(INTEGER))));
+    }
+
+    @Test
+    public void testMapOfArray()
+            throws Exception
+    {
+        Iterable<List<Integer>> arrays = createNullableTestArrays(limit(cycle(Arrays.asList(1, null, 3, 5, null, null, null, 7, 11, null, 13, 17)), 30_000));
+        Iterable<Integer> keys = intsBetween(0, 30_000);
+        Iterable<Map<Integer, List<Integer>>> values = createTestMaps(keys, arrays);
+        tester.testRoundTrip(getStandardMapObjectInspector(
+                javaIntObjectInspector,
+                getStandardListObjectInspector(javaIntObjectInspector)),
+                values, values, mapType(INTEGER, new ArrayType(INTEGER)));
+    }
+
+    @Test
+    public void testMapOfSingleLevelArray()
+            throws Exception
+    {
+        Iterable<List<Integer>> arrays = createNullableTestArrays(intsBetween(0, 30_000));
+        Iterable<Integer> keys = intsBetween(0, 30_000);
+        Iterable<Map<Integer, List<Integer>>> values = createTestMaps(keys, arrays);
+        tester.testSingleLevelArraySchemaRoundTrip(getStandardMapObjectInspector(
+                javaIntObjectInspector,
+                getStandardListObjectInspector(javaIntObjectInspector)),
+                values, values, mapType(INTEGER, new ArrayType(INTEGER)));
+    }
+
+    @Test
+    public void testMapOfStruct()
+            throws Exception
+    {
+        Iterable<Long> keys = longsBetween(0, 30_000);
+        Iterable<List> structs = createNullableTestStructs(transform(intsBetween(0, 30_000), Object::toString), longsBetween(0, 30_000));
+        List<String> structFieldNames = Arrays.asList("stringField", "longField");
+        Type structType = new RowType(ImmutableList.of(VARCHAR, BIGINT), Optional.of(structFieldNames));
+        Iterable<Map<Long, List>> values = createTestMaps(keys, structs);
+        tester.testRoundTrip(getStandardMapObjectInspector(
+                javaLongObjectInspector,
+                getStandardStructObjectInspector(structFieldNames, Arrays.asList(javaStringObjectInspector, javaLongObjectInspector))),
+                values, values, mapType(BIGINT, structType));
+    }
+
+    @Test
+    public void testMapWithNullValues()
+            throws Exception
+    {
+        Iterable<Integer> mapKeys = intsBetween(0, 31_234);
+        Iterable<String> mapValues = limit(cycle(Arrays.asList(null, "value2", "value3", null, null, "value6", "value7")), 31_234);
+        Iterable<Map<Integer, String>> values = createTestMaps(mapKeys, mapValues);
+        tester.testRoundTrip(getStandardMapObjectInspector(javaIntObjectInspector, javaStringObjectInspector), values, values, mapType(INTEGER, VARCHAR));
+    }
+
+    @Test
+    public void testStruct()
+            throws Exception
+    {
+        List<List> values = createTestStructs(transform(intsBetween(0, 31_234), Object::toString), longsBetween(0, 31_234));
+        List<String> structFieldNames = Arrays.asList("stringField", "longField");
+        Type structType = new RowType(ImmutableList.of(VARCHAR, BIGINT), Optional.of(structFieldNames));
+        tester.testRoundTrip(getStandardStructObjectInspector(structFieldNames, Arrays.asList(javaStringObjectInspector, javaLongObjectInspector)), values, values, structType);
+    }
+
+    @Test
+    public void testNestedStructs()
+            throws Exception
+    {
+        int nestingLevel = ThreadLocalRandom.current().nextInt(1, 15);
+        Optional<List<String>> structFieldNames = Optional.of(singletonList("structField"));
+        Iterable<?> values = limit(cycle(Arrays.asList(1, null, 3, null, 5, null, 7, null, null, null, 11, null, 13)), 3_210);
+        ObjectInspector objectInspector = getStandardStructObjectInspector(structFieldNames.get(), singletonList(javaIntObjectInspector));
+        Type type = new RowType(singletonList(INTEGER), structFieldNames);
+        for (int i = 0; i < nestingLevel; i++) {
+            values = createNullableTestStructs(values);
+            objectInspector = getStandardStructObjectInspector(structFieldNames.get(), singletonList(objectInspector));
+            type = new RowType(singletonList(type), structFieldNames);
+        }
+        values = createTestStructs(values);
+        tester.testRoundTrip(objectInspector, values, values, type);
+    }
+
+    @Test
+    public void testComplexNestedStructs()
+            throws Exception
+    {
+        final int n = 30;
+        Iterable<Integer> mapKeys = intsBetween(0, n);
+        Iterable<Integer> intPrimitives = limit(cycle(Arrays.asList(1, null, 3, null, 5, null, 7, null, null, null, 11, null, 13)), n);
+        Iterable<String> stringPrimitives = limit(cycle(Arrays.asList(null, "value2", "value3", null, null, "value6", "value7")), n);
+        Iterable<Double> doublePrimitives = limit(cycle(Arrays.asList(1.1, null, 3.3, null, 5.5, null, 7.7, null, null, null, 11.11, null, 13.13)), n);
+        Iterable<Boolean> booleanPrimitives = limit(cycle(Arrays.asList(null, true, false, null, null, true, false)), n);
+        Iterable<String> mapStringKeys = Stream.generate(() -> UUID.randomUUID().toString()).limit(n).collect(Collectors.toList());
+        Iterable<Map<Integer, String>> mapsIntString = createNullableTestMaps(mapKeys, stringPrimitives);
+        Iterable<List<String>> arraysString = createNullableTestArrays(stringPrimitives);
+        Iterable<Map<Integer, Double>> mapsIntDouble = createNullableTestMaps(mapKeys, doublePrimitives);
+        Iterable<List<Boolean>> arraysBoolean = createNullableTestArrays(booleanPrimitives);
+        Iterable<Map<String, String>> mapsStringString = createNullableTestMaps(mapStringKeys, stringPrimitives);
+
+        List<String> struct1FieldNames = Arrays.asList("mapIntStringField", "stringArrayField", "intField");
+        Iterable<?> stucts1 = createNullableTestStructs(mapsIntString, arraysString, intPrimitives);
+        ObjectInspector struct1ObjectInspector = getStandardStructObjectInspector(struct1FieldNames,
+                Arrays.asList(
+                        getStandardMapObjectInspector(javaIntObjectInspector, javaStringObjectInspector),
+                        getStandardListObjectInspector(javaStringObjectInspector),
+                        javaIntObjectInspector));
+        Type struct1Type = new RowType(ImmutableList.of(mapType(INTEGER, VARCHAR), new ArrayType(VARCHAR), INTEGER), Optional.of(struct1FieldNames));
+
+        List<String> struct2FieldNames = Arrays.asList("mapIntStringField", "stringArrayField", "structField");
+        Iterable<?> structs2 = createNullableTestStructs(mapsIntString, arraysString, stucts1);
+        ObjectInspector struct2ObjectInspector = getStandardStructObjectInspector(struct2FieldNames,
+                Arrays.asList(
+                        getStandardMapObjectInspector(javaIntObjectInspector, javaStringObjectInspector),
+                        getStandardListObjectInspector(javaStringObjectInspector),
+                        struct1ObjectInspector));
+        Type struct2Type = new RowType(ImmutableList.of(mapType(INTEGER, VARCHAR), new ArrayType(VARCHAR), struct1Type), Optional.of(struct2FieldNames));
+
+        List<String> struct3FieldNames = Arrays.asList("mapIntDoubleField", "booleanArrayField", "booleanField");
+        Iterable<?> structs3 = createNullableTestStructs(mapsIntDouble, arraysBoolean, booleanPrimitives);
+        ObjectInspector struct3ObjectInspector = getStandardStructObjectInspector(struct3FieldNames,
+                Arrays.asList(
+                        getStandardMapObjectInspector(javaIntObjectInspector, javaDoubleObjectInspector),
+                        getStandardListObjectInspector(javaBooleanObjectInspector),
+                        javaBooleanObjectInspector));
+        Type struct3Type = new RowType(ImmutableList.of(mapType(INTEGER, DOUBLE), new ArrayType(BOOLEAN), BOOLEAN), Optional.of(struct3FieldNames));
+
+        List<String> struct4FieldNames = Arrays.asList("mapIntDoubleField", "booleanArrayField", "structField");
+        Iterable<?> stucts4 = createNullableTestStructs(mapsIntDouble, arraysBoolean, structs3);
+        ObjectInspector struct4ObjectInspector = getStandardStructObjectInspector(struct4FieldNames,
+                Arrays.asList(
+                        getStandardMapObjectInspector(javaIntObjectInspector, javaDoubleObjectInspector),
+                        getStandardListObjectInspector(javaBooleanObjectInspector),
+                        struct3ObjectInspector));
+        Type struct4Type = new RowType(ImmutableList.of(mapType(INTEGER, DOUBLE), new ArrayType(BOOLEAN), struct3Type), Optional.of(struct4FieldNames));
+
+        List<String> structFieldNames = Arrays.asList("structField1", "structField2", "structField3", "structField4", "mapIntDoubleField", "booleanArrayField", "mapStringStringField");
+        List<ObjectInspector> objectInspectors =
+                Arrays.asList(
+                        struct1ObjectInspector,
+                        struct2ObjectInspector,
+                        struct3ObjectInspector,
+                        struct4ObjectInspector,
+                        getStandardMapObjectInspector(javaIntObjectInspector, javaDoubleObjectInspector),
+                        getStandardListObjectInspector(javaBooleanObjectInspector),
+                        getStandardMapObjectInspector(javaStringObjectInspector, javaStringObjectInspector));
+        List<Type> types = ImmutableList.of(struct1Type, struct2Type, struct3Type, struct4Type, mapType(INTEGER, DOUBLE), new ArrayType(BOOLEAN), mapType(VARCHAR, VARCHAR));
+
+        Iterable<?>[] values = new Iterable<?>[] {stucts1, structs2, structs3, stucts4, mapsIntDouble, arraysBoolean, mapsStringString};
+        tester.assertRoundTrip(objectInspectors, values, values, structFieldNames, types, Optional.empty());
+    }
+
+    @Test
+    public void testStructOfMaps()
+            throws Exception
+    {
+        Iterable<Integer> mapKeys = Stream.generate(() -> ThreadLocalRandom.current().nextInt(10_000)).limit(10_000).collect(Collectors.toList());
+        Iterable<Integer> intPrimitives = limit(cycle(Arrays.asList(1, null, 3, null, 5, null, 7, null, null, null, 11, null, 13)), 10_000);
+        Iterable<String> stringPrimitives = limit(cycle(Arrays.asList(null, "value2", "value3", null, null, "value6", "value7")), 10_000);
+        Iterable<Map<Integer, String>> maps = createNullableTestMaps(mapKeys, stringPrimitives);
+        Iterable<List<String>> stringArrayField = createNullableTestArrays(stringPrimitives);
+        List<List> values = createTestStructs(maps, stringArrayField, intPrimitives);
+        List<String> structFieldNames = Arrays.asList("mapIntStringField", "stringArrayField", "intField");
+
+        Type structType = new RowType(ImmutableList.of(mapType(INTEGER, VARCHAR), new ArrayType(VARCHAR), INTEGER), Optional.of(structFieldNames));
+        tester.testRoundTrip(getStandardStructObjectInspector(structFieldNames,
+                Arrays.asList(
+                        getStandardMapObjectInspector(javaIntObjectInspector, javaStringObjectInspector),
+                        getStandardListObjectInspector(javaStringObjectInspector),
+                        javaIntObjectInspector)),
+                values, values, structType);
+    }
+
+    @Test
+    public void testStructOfNullableMapBetweenNonNullFields()
+            throws Exception
+    {
+        Iterable<Integer> intPrimitives = intsBetween(0, 10_000);
+        Iterable<String> stringPrimitives = limit(cycle(Arrays.asList(null, "value2", "value3", null, null, "value6", "value7")), 10_000);
+        Iterable<Map<Integer, String>> maps = createNullableTestMaps(intPrimitives, stringPrimitives);
+        List<List> values = createTestStructs(intPrimitives, maps, intPrimitives);
+        List<String> structFieldNames = Arrays.asList("intField1", "mapIntStringField", "intField2");
+
+        Type structType = new RowType(ImmutableList.of(INTEGER, mapType(INTEGER, VARCHAR), INTEGER), Optional.of(structFieldNames));
+        tester.testRoundTrip(getStandardStructObjectInspector(structFieldNames,
+                Arrays.asList(
+                        javaIntObjectInspector,
+                        getStandardMapObjectInspector(javaIntObjectInspector, javaStringObjectInspector),
+                        javaIntObjectInspector)),
+                values, values, structType);
+    }
+
+    @Test
+    public void testStructOfNullableArrayBetweenNonNullFields()
+            throws Exception
+    {
+        Iterable<Integer> intPrimitives = intsBetween(0, 10_000);
+        Iterable<String> stringPrimitives = limit(cycle(Arrays.asList(null, "value2", "value3", null, null, "value6", "value7")), 10_000);
+        Iterable<List<String>> stringArrayField = createNullableTestArrays(stringPrimitives);
+        List<List> values = createTestStructs(intPrimitives, stringArrayField, intPrimitives);
+        List<String> structFieldNames = Arrays.asList("intField1", "arrayStringField", "intField2");
+
+        Type structType = new RowType(ImmutableList.of(INTEGER, new ArrayType(VARCHAR), INTEGER), Optional.of(structFieldNames));
+        tester.testRoundTrip(getStandardStructObjectInspector(structFieldNames,
+                Arrays.asList(
+                        javaIntObjectInspector,
+                        getStandardListObjectInspector(javaStringObjectInspector),
+                        javaIntObjectInspector)),
+                values, values, structType);
+    }
+
+    @Test
+    public void testStructOfArrayAndPrimitive()
+            throws Exception
+    {
+        Iterable<List<String>> stringArrayField = createNullableTestArrays(transform(intsBetween(0, 31_234), Object::toString));
+        List<List> values = createTestStructs(stringArrayField, limit(cycle(ImmutableList.of(1, 3, 5, 7, 11, 13, 17)), 31_234));
+        List<String> structFieldNames = Arrays.asList("stringArrayField", "intField");
+
+        Type structType = new RowType(ImmutableList.of(new ArrayType(VARCHAR), INTEGER), Optional.of(structFieldNames));
+        tester.testRoundTrip(getStandardStructObjectInspector(structFieldNames,
+                Arrays.asList(getStandardListObjectInspector(javaStringObjectInspector), javaIntObjectInspector)), values, values, structType);
+    }
+
+    @Test
+    public void testStructOfSingleLevelArrayAndPrimitive()
+            throws Exception
+    {
+        Iterable<List<String>> stringArrayField = createNullableTestArrays(transform(intsBetween(0, 31_234), Object::toString));
+        List<List> values = createTestStructs(stringArrayField, limit(cycle(ImmutableList.of(1, 3, 5, 7, 11, 13, 17)), 31_234));
+        List<String> structFieldNames = Arrays.asList("stringArrayField", "intField");
+
+        Type structType = new RowType(ImmutableList.of(new ArrayType(VARCHAR), INTEGER), Optional.of(structFieldNames));
+        tester.testSingleLevelArraySchemaRoundTrip(getStandardStructObjectInspector(structFieldNames,
+                Arrays.asList(getStandardListObjectInspector(javaStringObjectInspector), javaIntObjectInspector)), values, values, structType);
+    }
+
+    @Test
+    public void testStructOfPrimitiveAndArray()
+            throws Exception
+    {
+        Iterable<List<String>> stringArrayField = createNullableTestArrays(transform(intsBetween(0, 31_234), Object::toString));
+        Iterable<Integer> intField = limit(cycle(ImmutableList.of(1, 3, 5, 7, 11, 13, 17)), 31_234);
+        List<List> values = createTestStructs(intField, stringArrayField);
+        List<String> structFieldNames = Arrays.asList("intField", "stringArrayField");
+
+        Type structType = new RowType(ImmutableList.of(INTEGER, new ArrayType(VARCHAR)), Optional.of(structFieldNames));
+        tester.testRoundTrip(getStandardStructObjectInspector(structFieldNames,
+                Arrays.asList(javaIntObjectInspector, getStandardListObjectInspector(javaStringObjectInspector))), values, values, structType);
+    }
+
+    @Test
+    public void testStructOfPrimitiveAndSingleLevelArray()
+            throws Exception
+    {
+        Iterable<List<String>> stringArrayField = createNullableTestArrays(transform(intsBetween(0, 31_234), Object::toString));
+        Iterable<Integer> intField = limit(cycle(ImmutableList.of(1, 3, 5, 7, 11, 13, 17)), 31_234);
+        List<List> values = createTestStructs(intField, stringArrayField);
+        List<String> structFieldNames = Arrays.asList("intField", "stringArrayField");
+
+        Type structType = new RowType(ImmutableList.of(INTEGER, new ArrayType(VARCHAR)), Optional.of(structFieldNames));
+        tester.testSingleLevelArraySchemaRoundTrip(getStandardStructObjectInspector(structFieldNames,
+                Arrays.asList(javaIntObjectInspector, getStandardListObjectInspector(javaStringObjectInspector))), values, values, structType);
+    }
+
+    @Test
+    public void testStructOfTwoArrays()
+            throws Exception
+    {
+        Iterable<List<Integer>> intArrayField = createNullableTestArrays(limit(cycle(ImmutableList.of(1, 3, 5, 7, 11, 13, 17)), 30_000));
+        Iterable<List<String>> stringArrayField = createNullableTestArrays(transform(intsBetween(0, 30_000), Object::toString));
+        List<List> values = createTestStructs(stringArrayField, intArrayField);
+        List<String> structFieldNames = Arrays.asList("stringArrayField", "intArrayField");
+
+        Type structType = new RowType(ImmutableList.of(new ArrayType(VARCHAR), new ArrayType(INTEGER)), Optional.of(structFieldNames));
+        tester.testRoundTrip(getStandardStructObjectInspector(structFieldNames,
+                Arrays.asList(getStandardListObjectInspector(javaStringObjectInspector), getStandardListObjectInspector(javaIntObjectInspector))), values, values, structType);
+    }
+
+    @Test
+    public void testStructOfTwoNestedArrays()
+            throws Exception
+    {
+        Iterable<List<List<Integer>>> intArrayField = createNullableTestArrays(createNullableTestArrays(limit(cycle(ImmutableList.of(1, 3, 5, 7, 11, 13, 17)), 30_000)));
+        Iterable<List<List<String>>> stringArrayField = createNullableTestArrays(createNullableTestArrays(transform(intsBetween(0, 31_234), Object::toString)));
+        List<List> values = createTestStructs(stringArrayField, intArrayField);
+        List<String> structFieldNames = Arrays.asList("stringArrayField", "intArrayField");
+
+        Type structType = new RowType(ImmutableList.of(new ArrayType(new ArrayType(VARCHAR)), new ArrayType(new ArrayType(INTEGER))), Optional.of(structFieldNames));
+        tester.testRoundTrip(getStandardStructObjectInspector(structFieldNames,
+                Arrays.asList(
+                        getStandardListObjectInspector(getStandardListObjectInspector(javaStringObjectInspector)),
+                        getStandardListObjectInspector(getStandardListObjectInspector(javaIntObjectInspector)))),
+                values, values, structType);
+    }
+
+    @Test
+    public void testStructOfTwoNestedSingleLevelSchemaArrays()
+            throws Exception
+    {
+        Iterable<List<List<Integer>>> intArrayField = createNullableTestArrays(createTestArrays(limit(cycle(ImmutableList.of(1, 3, 5, 7, 11, 13, 17)), 30_000)));
+        Iterable<List<List<String>>> stringArrayField = createNullableTestArrays(createTestArrays(transform(intsBetween(0, 31_234), Object::toString)));
+        List<List> values = createTestStructs(stringArrayField, intArrayField);
+        List<String> structFieldNames = Arrays.asList("stringArrayField", "intArrayField");
+
+        Type structType = new RowType(ImmutableList.of(new ArrayType(new ArrayType(VARCHAR)), new ArrayType(new ArrayType(INTEGER))), Optional.of(structFieldNames));
+        ObjectInspector objectInspector = getStandardStructObjectInspector(structFieldNames,
+                Arrays.asList(
+                        getStandardListObjectInspector(getStandardListObjectInspector(javaStringObjectInspector)),
+                        getStandardListObjectInspector(getStandardListObjectInspector(javaIntObjectInspector))));
+        tester.testSingleLevelArraySchemaRoundTrip(objectInspector, values, values, structType);
     }
 
     @Test
@@ -200,7 +814,6 @@ public abstract class AbstractTestParquetReader
     {
         for (int precision = MAX_PRECISION_INT64 + 1; precision < MAX_PRECISION; precision++) {
             int scale = ThreadLocalRandom.current().nextInt(precision);
-            MessageType parquetSchema = parseMessageType(format("message hive_decimal { optional FIXED_LEN_BYTE_ARRAY(16) test (DECIMAL(%d, %d)); }", precision, scale));
             ContiguousSet<BigInteger> values = bigIntegersBetween(BigDecimal.valueOf(Math.pow(10, precision - 1)).toBigInteger(), BigDecimal.valueOf(Math.pow(10, precision)).toBigInteger());
             ImmutableList.Builder<SqlDecimal> expectedValues = new ImmutableList.Builder<>();
             ImmutableList.Builder<HiveDecimal> writeValues = new ImmutableList.Builder<>();
@@ -211,9 +824,419 @@ public abstract class AbstractTestParquetReader
             tester.testRoundTrip(new JavaHiveDecimalObjectInspector(new DecimalTypeInfo(precision, scale)),
                     writeValues.build(),
                     expectedValues.build(),
-                    createDecimalType(precision, scale),
-                    Optional.of(parquetSchema));
+                    createDecimalType(precision, scale));
         }
+    }
+
+    @Test
+    public void testSchemaWithRepeatedOptionalRequiredFields()
+            throws Exception
+    {
+        MessageType parquetSchema = parseMessageType("message hive_schema {" +
+                "  optional group address_book {" +
+                "    required binary owner (UTF8);" +
+                "    optional group owner_phone_numbers (LIST) {" +
+                "      repeated group bag {" +
+                "        optional binary array_element (UTF8);" +
+                "      }" +
+                "    }" +
+                "    optional group contacts (LIST) {" +
+                "      repeated group bag {" +
+                "        optional group array_element {" +
+                "          required binary name (UTF8);" +
+                "          optional binary phone_number (UTF8);" +
+                "        }" +
+                "      }" +
+                "    }" +
+                "  }" +
+                "} ");
+
+        Iterable<String> owner = limit(cycle(Arrays.asList("owner1", "owner2", "owner3")), 50_000);
+        Iterable<List<String>> ownerPhoneNumbers = limit(cycle(Arrays.asList(null, Arrays.asList("phoneNumber2", "phoneNumber3", null), Arrays.asList(null, "phoneNumber6", "phoneNumber7"))), 50_000);
+        Iterable<String> name = Arrays.asList("name1", "name2", "name3", "name4", "name5", "name6", "name7");
+        Iterable<String> phoneNumber = Arrays.asList(null, "phoneNumber2", "phoneNumber3", null, null, "phoneNumber6", "phoneNumber7");
+        Iterable<List> contact = createNullableTestStructs(name, phoneNumber);
+        Iterable<List<List>> contacts = createNullableTestArrays(limit(cycle(contact), 50_000));
+        List<List> values = createTestStructs(owner, ownerPhoneNumbers, contacts);
+        List<String> addressBookFieldNames = Arrays.asList("owner", "owner_phone_numbers", "contacts");
+        List<String> contactsFieldNames = Arrays.asList("name", "phone_number");
+        Type contactsType = new ArrayType(new RowType(ImmutableList.of(VARCHAR, VARCHAR), Optional.of(contactsFieldNames)));
+        Type addressBookType = new RowType(ImmutableList.of(VARCHAR, new ArrayType(VARCHAR), contactsType), Optional.of(addressBookFieldNames));
+        tester.testRoundTrip(getStandardStructObjectInspector(addressBookFieldNames,
+                Arrays.asList(
+                        javaStringObjectInspector,
+                        getStandardListObjectInspector(javaStringObjectInspector),
+                        getStandardListObjectInspector(
+                                getStandardStructObjectInspector(contactsFieldNames, Arrays.asList(javaStringObjectInspector, javaStringObjectInspector))))),
+                values, values, addressBookType, Optional.of(parquetSchema));
+    }
+
+    @Test
+    public void testSchemaWithOptionalOptionalRequiredFields()
+            throws Exception
+    {
+        MessageType parquetSchema = parseMessageType("message hive_schema {" +
+                "  optional group a {" +
+                "    optional group b {" +
+                "      optional group c {" +
+                "        required binary d (UTF8);" +
+                "      }" +
+                "    }" +
+                "  }" +
+                "} ");
+        Type cType = new RowType(singletonList(VARCHAR), Optional.of(singletonList("d")));
+        Type bType = new RowType(singletonList(cType), Optional.of(singletonList("c")));
+        Type aType = new RowType(singletonList(bType), Optional.of(singletonList("b")));
+        Iterable<String> dValues = Arrays.asList("d1", "d2", "d3", "d4", "d5", "d6", "d7");
+        Iterable<List> cValues = createNullableTestStructs(dValues);
+        Iterable<List> bValues = createNullableTestStructs(cValues);
+        List<List> aValues = createTestStructs(bValues);
+        ObjectInspector cInspector = getStandardStructObjectInspector(singletonList("d"), singletonList(javaStringObjectInspector));
+        ObjectInspector bInspector = getStandardStructObjectInspector(singletonList("c"), singletonList(cInspector));
+        ObjectInspector aInspector = getStandardStructObjectInspector(singletonList("b"), singletonList(bInspector));
+        tester.testRoundTrip(aInspector, aValues, aValues, aType, Optional.of(parquetSchema));
+    }
+
+    @Test
+    public void testSchemaWithOptionalRequiredOptionalFields()
+            throws Exception
+    {
+        MessageType parquetSchema = parseMessageType("message hive_schema {" +
+                "  optional group a {" +
+                "    optional group b {" +
+                "      required group c {" +
+                "        optional int32 d;" +
+                "      }" +
+                "    }" +
+                "  }" +
+                "} ");
+        Type cType = new RowType(singletonList(INTEGER), Optional.of(singletonList("d")));
+        Type bType = new RowType(singletonList(cType), Optional.of(singletonList("c")));
+        Type aType = new RowType(singletonList(bType), Optional.of(singletonList("b")));
+        Iterable<Integer> dValues = Arrays.asList(111, null, 333, 444, null, 666, 777);
+        List<List> cValues = createTestStructs(dValues);
+        Iterable<List> bValues = createNullableTestStructs(cValues);
+        List<List> aValues = createTestStructs(bValues);
+        ObjectInspector cInspector = getStandardStructObjectInspector(singletonList("d"), singletonList(javaIntObjectInspector));
+        ObjectInspector bInspector = getStandardStructObjectInspector(singletonList("c"), singletonList(cInspector));
+        ObjectInspector aInspector = getStandardStructObjectInspector(singletonList("b"), singletonList(bInspector));
+        tester.testRoundTrip(aInspector, aValues, aValues, aType, Optional.of(parquetSchema));
+    }
+
+    @Test
+    public void testSchemaWithRequiredRequiredOptionalFields()
+            throws Exception
+    {
+        MessageType parquetSchema = parseMessageType("message hive_schema {" +
+                "  optional group a {" +
+                "    required group b {" +
+                "      required group c {" +
+                "        optional int32 d;" +
+                "      }" +
+                "    }" +
+                "  }" +
+                "} ");
+        Type cType = new RowType(singletonList(INTEGER), Optional.of(singletonList("d")));
+        Type bType = new RowType(singletonList(cType), Optional.of(singletonList("c")));
+        Type aType = new RowType(singletonList(bType), Optional.of(singletonList("b")));
+        Iterable<Integer> dValues = Arrays.asList(111, null, 333, 444, null, 666, 777);
+        List<List> cValues = createTestStructs(dValues);
+        List<List> bValues = createTestStructs(cValues);
+        List<List> aValues = createTestStructs(bValues);
+        ObjectInspector cInspector = getStandardStructObjectInspector(singletonList("d"), singletonList(javaIntObjectInspector));
+        ObjectInspector bInspector = getStandardStructObjectInspector(singletonList("c"), singletonList(cInspector));
+        ObjectInspector aInspector = getStandardStructObjectInspector(singletonList("b"), singletonList(bInspector));
+        tester.testRoundTrip(aInspector, aValues, aValues, aType, Optional.of(parquetSchema));
+    }
+
+    @Test
+    public void testSchemaWithRequiredOptionalOptionalFields()
+            throws Exception
+    {
+        MessageType parquetSchema = parseMessageType("message hive_schema {" +
+                "  optional group a {" +
+                "    required group b {" +
+                "      optional group c {" +
+                "        optional int32 d;" +
+                "      }" +
+                "    }" +
+                "  }" +
+                "} ");
+        Type cType = new RowType(singletonList(INTEGER), Optional.of(singletonList("d")));
+        Type bType = new RowType(singletonList(cType), Optional.of(singletonList("c")));
+        Type aType = new RowType(singletonList(bType), Optional.of(singletonList("b")));
+        Iterable<Integer> dValues = Arrays.asList(111, null, 333, 444, null, 666, 777);
+        Iterable<List> cValues = createNullableTestStructs(dValues);
+        List<List> bValues = createTestStructs(cValues);
+        List<List> aValues = createTestStructs(bValues);
+        ObjectInspector cInspector = getStandardStructObjectInspector(singletonList("d"), singletonList(javaIntObjectInspector));
+        ObjectInspector bInspector = getStandardStructObjectInspector(singletonList("c"), singletonList(cInspector));
+        ObjectInspector aInspector = getStandardStructObjectInspector(singletonList("b"), singletonList(bInspector));
+        tester.testRoundTrip(aInspector, aValues, aValues, aType, Optional.of(parquetSchema));
+    }
+
+    @Test
+    public void testSchemaWithRequiredOptionalRequiredFields()
+            throws Exception
+    {
+        MessageType parquetSchema = parseMessageType("message hive_schema {" +
+                "  optional group a {" +
+                "    required group b {" +
+                "      optional group c {" +
+                "        required binary d (UTF8);" +
+                "      }" +
+                "    }" +
+                "  }" +
+                "} ");
+        Type cType = new RowType(singletonList(VARCHAR), Optional.of(singletonList("d")));
+        Type bType = new RowType(singletonList(cType), Optional.of(singletonList("c")));
+        Type aType = new RowType(singletonList(bType), Optional.of(singletonList("b")));
+        Iterable<String> dValues = Arrays.asList("d1", "d2", "d3", "d4", "d5", "d6", "d7");
+        Iterable<List> cValues = createNullableTestStructs(dValues);
+        List<List> bValues = createTestStructs(cValues);
+        List<List> aValues = createTestStructs(bValues);
+        ObjectInspector cInspector = getStandardStructObjectInspector(singletonList("d"), singletonList(javaStringObjectInspector));
+        ObjectInspector bInspector = getStandardStructObjectInspector(singletonList("c"), singletonList(cInspector));
+        ObjectInspector aInspector = getStandardStructObjectInspector(singletonList("b"), singletonList(bInspector));
+        tester.testRoundTrip(aInspector, aValues, aValues, aType, Optional.of(parquetSchema));
+    }
+
+    @Test
+    public void testSchemaWithRequiredOptionalRequired2Fields()
+            throws Exception
+    {
+        MessageType parquetSchema = parseMessageType("message hive_schema {" +
+                "  optional group a {" +
+                "    required group b {" +
+                "      optional group c {" +
+                "        required binary d (UTF8);" +
+                "      }" +
+                "    }" +
+                "  }" +
+                "  optional group e {" +
+                "    required group f {" +
+                "      optional group g {" +
+                "        required binary h (UTF8);" +
+                "      }" +
+                "    }" +
+                "  }" +
+                "} ");
+
+        Type cType = new RowType(singletonList(VARCHAR), Optional.of(singletonList("d")));
+        Type bType = new RowType(singletonList(cType), Optional.of(singletonList("c")));
+        Type aType = new RowType(singletonList(bType), Optional.of(singletonList("b")));
+        Iterable<String> dValues = Arrays.asList("d1", "d2", "d3", "d4", "d5", "d6", "d7");
+        Iterable<List> cValues = createNullableTestStructs(dValues);
+        List<List> bValues = createTestStructs(cValues);
+        List<List> aValues = createTestStructs(bValues);
+
+        Type gType = new RowType(singletonList(VARCHAR), Optional.of(singletonList("h")));
+        Type fType = new RowType(singletonList(gType), Optional.of(singletonList("g")));
+        Type eType = new RowType(singletonList(fType), Optional.of(singletonList("f")));
+        Iterable<String> hValues = Arrays.asList("h1", "h2", "h3", "h4", "h5", "h6", "h7");
+        Iterable<List> gValues = createNullableTestStructs(hValues);
+        List<List> fValues = createTestStructs(gValues);
+        List<List> eValues = createTestStructs(fValues);
+
+        ObjectInspector cInspector = getStandardStructObjectInspector(singletonList("d"), singletonList(javaStringObjectInspector));
+        ObjectInspector bInspector = getStandardStructObjectInspector(singletonList("c"), singletonList(cInspector));
+        ObjectInspector aInspector = getStandardStructObjectInspector(singletonList("b"), singletonList(bInspector));
+        ObjectInspector gInspector = getStandardStructObjectInspector(singletonList("h"), singletonList(javaStringObjectInspector));
+        ObjectInspector fInspector = getStandardStructObjectInspector(singletonList("g"), singletonList(gInspector));
+        ObjectInspector eInspector = getStandardStructObjectInspector(singletonList("f"), singletonList(fInspector));
+        tester.testRoundTrip(Arrays.asList(aInspector, eInspector),
+                new Iterable<?>[] {aValues, eValues}, new Iterable<?>[] {aValues, eValues},
+                Arrays.asList("a", "e"), Arrays.asList(aType, eType), Optional.of(parquetSchema));
+    }
+
+    @Test
+    public void testOldAvroArray()
+            throws Exception
+    {
+        MessageType parquetMrAvroSchema = parseMessageType("message avro_schema_old {" +
+                "  optional group my_list (LIST){" +
+                "        repeated int32 array;" +
+                "  }" +
+                "} ");
+        Iterable<List<Integer>> nonNullArrayElements = createTestArrays(intsBetween(0, 31_234));
+        tester.testRoundTrip(getStandardListObjectInspector(javaIntObjectInspector), nonNullArrayElements, nonNullArrayElements, new ArrayType(INTEGER), Optional.of(parquetMrAvroSchema));
+    }
+
+    @Test
+    public void testNewAvroArray()
+            throws Exception
+    {
+        MessageType parquetMrAvroSchema = parseMessageType("message avro_schema_new { " +
+                "  optional group my_list (LIST) { " +
+                "    repeated group list { " +
+                "      optional int32 element; " +
+                "    } " +
+                "  } " +
+                "}");
+        Iterable<List<Integer>> values = createTestArrays(limit(cycle(Arrays.asList(1, null, 3, 5, null, null, null, 7, 11, null, 13, 17)), 30_000));
+        tester.testRoundTrip(getStandardListObjectInspector(javaIntObjectInspector), values, values, new ArrayType(INTEGER), Optional.of(parquetMrAvroSchema));
+    }
+
+    /**
+     * Test reading various arrays schemas compatible with spec
+     * https://github.com/apache/parquet-format/blob/master/LogicalTypes.md#lists
+     */
+    @Test
+    public void testArraySchemas()
+            throws Exception
+    {
+        MessageType parquetMrNullableSpecSchema = parseMessageType("message hive_schema {" +
+                "  optional group my_list (LIST){" +
+                "    repeated group list {" +
+                "        required int32 element;" +
+                "    }" +
+                "  }" +
+                "} ");
+        Iterable<List<Integer>> nonNullArrayElements = createTestArrays(intsBetween(0, 31_234));
+        tester.testRoundTrip(getStandardListObjectInspector(javaIntObjectInspector), nonNullArrayElements, nonNullArrayElements, new ArrayType(INTEGER), Optional.of(parquetMrNullableSpecSchema));
+
+        MessageType parquetMrNonNullSpecSchema = parseMessageType("message hive_schema {" +
+                "  required group my_list (LIST){" +
+                "    repeated group list {" +
+                "        optional int32 element;" +
+                "    }" +
+                "  }" +
+                "} ");
+        Iterable<List<Integer>> values = createTestArrays(limit(cycle(Arrays.asList(1, null, 3, 5, null, null, null, 7, 11, null, 13, 17)), 30_000));
+        tester.assertRoundTrip(singletonList(getStandardListObjectInspector(javaIntObjectInspector)), new Iterable<?>[] {values}, new Iterable<?>[] {
+                values}, singletonList("my_list"), singletonList(new ArrayType(INTEGER)), Optional.of(parquetMrNonNullSpecSchema));
+
+        MessageType sparkSchema = parseMessageType("message hive_schema {" +
+                "  optional group my_list (LIST){" +
+                "    repeated group list {" +
+                "        optional int32 element;" +
+                "    }" +
+                "  }" +
+                "} ");
+        tester.testRoundTrip(getStandardListObjectInspector(javaIntObjectInspector), values, values, new ArrayType(INTEGER), Optional.of(sparkSchema));
+
+        MessageType hiveSchema = parseMessageType("message hive_schema {" +
+                "  optional group my_list (LIST){" +
+                "    repeated group bag {" +
+                "        optional int32 array_element;" +
+                "    }" +
+                "  }" +
+                "} ");
+        tester.testRoundTrip(getStandardListObjectInspector(javaIntObjectInspector), values, values, new ArrayType(INTEGER), Optional.of(hiveSchema));
+
+        MessageType customNamingSchema = parseMessageType("message hive_schema {" +
+                "  optional group my_list (LIST){" +
+                "    repeated group bag {" +
+                "        optional int32 array;" +
+                "    }" +
+                "  }" +
+                "} ");
+        tester.testRoundTrip(getStandardListObjectInspector(javaIntObjectInspector), values, values, new ArrayType(INTEGER), Optional.of(customNamingSchema));
+    }
+
+    /**
+     * Test reading various maps schemas compatible with spec
+     * https://github.com/apache/parquet-format/blob/master/LogicalTypes.md#maps
+     */
+    @Test
+    public void testMapSchemas()
+            throws Exception
+    {
+        Iterable<Map<String, Integer>> values = createTestMaps(transform(intsBetween(0, 100_000), Object::toString), intsBetween(0, 10_000));
+        Iterable<Map<String, Integer>> nullableValues = createTestMaps(transform(intsBetween(0, 30_000), Object::toString), limit(cycle(Arrays.asList(1, null, 3, 5, null, null, null, 7, 11, null, 13, 17)), 30_000));
+        tester.testRoundTrip(getStandardMapObjectInspector(javaStringObjectInspector, javaIntObjectInspector), values, values, mapType(VARCHAR, INTEGER));
+
+        // Map<String, Integer> (nullable map, non-null values)
+        MessageType map = parseMessageType("message hive_schema {" +
+                " optional group my_map (MAP) {" +
+                "     repeated group map { " +
+                "        required binary str (UTF8);   " +
+                "        required int32 num;  " +
+                "    }  " +
+                "  }" +
+                "}   ");
+        tester.testRoundTrip(getStandardMapObjectInspector(javaStringObjectInspector, javaIntObjectInspector), values, values, mapType(VARCHAR, INTEGER), Optional.of(map));
+
+        // Map<String, Integer> (nullable map, non-null values)
+        map = parseMessageType("message hive_schema {" +
+                " optional group my_map (MAP_KEY_VALUE) {" +
+                "     repeated group map { " +
+                "        required binary str (UTF8);   " +
+                "        required int32 num;  " +
+                "    }  " +
+                "  }" +
+                "}   ");
+        tester.testRoundTrip(getStandardMapObjectInspector(javaStringObjectInspector, javaIntObjectInspector), values, values, mapType(VARCHAR, INTEGER), Optional.of(map));
+
+        // Map<String, Integer> (non-null map, nullable values)
+        map = parseMessageType("message hive_schema {" +
+                " required group my_map (MAP) { " +
+                "    repeated group map {  " +
+                "        required binary key (UTF8);      " +
+                "       optional int32 value;   " +
+                "    }   " +
+                "  }" +
+                " }  ");
+        tester.assertRoundTrip(singletonList(getStandardMapObjectInspector(javaStringObjectInspector, javaIntObjectInspector)), new Iterable<?>[] {nullableValues},
+                new Iterable<?>[] {nullableValues}, singletonList("my_map"), singletonList(mapType(VARCHAR, INTEGER)), Optional.of(map));
+
+        // Map<String, Integer> (non-null map, nullable values)
+        map = parseMessageType("message hive_schema {" +
+                " required group my_map (MAP_KEY_VALUE) { " +
+                "    repeated group map {  " +
+                "        required binary key (UTF8);      " +
+                "       optional int32 value;   " +
+                "    }   " +
+                "  }" +
+                " }  ");
+        tester.assertRoundTrip(singletonList(getStandardMapObjectInspector(javaStringObjectInspector, javaIntObjectInspector)), new Iterable<?>[] {nullableValues},
+                new Iterable<?>[] {nullableValues}, singletonList("my_map"), singletonList(mapType(VARCHAR, INTEGER)), Optional.of(map));
+
+        // Map<String, Integer> (non-null map, nullable values)
+        map = parseMessageType("message hive_schema {" +
+                " required group my_map (MAP) { " +
+                "    repeated group map {  " +
+                "        required binary key (UTF8);      " +
+                "       required int32 value;   " +
+                "    }   " +
+                "  }" +
+                " }  ");
+        tester.assertRoundTrip(singletonList(getStandardMapObjectInspector(javaStringObjectInspector, javaIntObjectInspector)), new Iterable<?>[] {values},
+                new Iterable<?>[] {values}, singletonList("my_map"), singletonList(mapType(VARCHAR, INTEGER)), Optional.of(map));
+
+        // Map<String, Integer> (non-null map, nullable values)
+        map = parseMessageType("message hive_schema {" +
+                " required group my_map (MAP_KEY_VALUE) { " +
+                "    repeated group map {  " +
+                "        required binary key (UTF8);      " +
+                "       required int32 value;   " +
+                "    }   " +
+                "  }" +
+                " }  ");
+        tester.assertRoundTrip(singletonList(getStandardMapObjectInspector(javaStringObjectInspector, javaIntObjectInspector)), new Iterable<?>[] {values},
+                new Iterable<?>[] {values}, singletonList("my_map"), singletonList(mapType(VARCHAR, INTEGER)), Optional.of(map));
+
+        // Map<String, Integer> (nullable map, nullable values)
+        map = parseMessageType("message hive_schema {" +
+                " optional group my_map (MAP) { " +
+                "    repeated group map {  " +
+                "       required binary key (UTF8);      " +
+                "       optional int32 value;   " +
+                "    }   " +
+                "  }" +
+                " }  ");
+        tester.testRoundTrip(getStandardMapObjectInspector(javaStringObjectInspector, javaIntObjectInspector), nullableValues, nullableValues, mapType(VARCHAR, INTEGER), Optional.of(map));
+
+        // Map<String, Integer> (nullable map, nullable values)
+        map = parseMessageType("message hive_schema {" +
+                " optional group my_map (MAP_KEY_VALUE) { " +
+                "    repeated group map {  " +
+                "       required binary key (UTF8);      " +
+                "       optional int32 value;   " +
+                "    }   " +
+                "  }" +
+                " }  ");
+        tester.testRoundTrip(getStandardMapObjectInspector(javaStringObjectInspector, javaIntObjectInspector), nullableValues, nullableValues, mapType(VARCHAR, INTEGER), Optional.of(map));
     }
 
     @Test
@@ -236,7 +1259,7 @@ public abstract class AbstractTestParquetReader
                 AbstractTestParquetReader::shortToInt,
                 INTEGER);
 
-        tester.testRoundTrip(javaIntObjectInspector, writeValues, writeValues, INTEGER);
+        tester.testRoundTrip(javaIntObjectInspector, writeValues, INTEGER);
         tester.testRoundTrip(javaLongObjectInspector, transform(writeValues, AbstractTestParquetReader::intToLong), BIGINT);
         tester.testRoundTrip(javaTimestampObjectInspector,
                 transform(writeValues, AbstractTestParquetReader::intToTimestamp),
@@ -448,17 +1471,90 @@ public abstract class AbstractTestParquetReader
 
     private static ContiguousSet<Integer> intsBetween(int lowerInclusive, int upperExclusive)
     {
-        return ContiguousSet.create(Range.openClosed(lowerInclusive, upperExclusive), DiscreteDomain.integers());
+        return ContiguousSet.create(Range.closedOpen(lowerInclusive, upperExclusive), DiscreteDomain.integers());
     }
 
     private static ContiguousSet<Long> longsBetween(long lowerInclusive, long upperExclusive)
     {
-        return ContiguousSet.create(Range.openClosed(lowerInclusive, upperExclusive), DiscreteDomain.longs());
+        return ContiguousSet.create(Range.closedOpen(lowerInclusive, upperExclusive), DiscreteDomain.longs());
     }
 
     private static ContiguousSet<BigInteger> bigIntegersBetween(BigInteger lowerInclusive, BigInteger upperExclusive)
     {
-        return ContiguousSet.create(Range.openClosed(lowerInclusive, upperExclusive), DiscreteDomain.bigIntegers());
+        return ContiguousSet.create(Range.closedOpen(lowerInclusive, upperExclusive), DiscreteDomain.bigIntegers());
+    }
+
+    private <F> List<List> createTestStructs(Iterable<F> fieldValues)
+    {
+        checkArgument(fieldValues.iterator().hasNext(), "struct field values cannot be empty");
+        List<List> structs = new ArrayList<>();
+        for (F field : fieldValues) {
+            structs.add(singletonList(field));
+        }
+        return structs;
+    }
+
+    private List<List> createTestStructs(Iterable<?>... values)
+    {
+        List<List> structs = new ArrayList<>();
+        List<Iterator> iterators = Arrays.stream(values).map(Iterable::iterator).collect(Collectors.toList());
+        iterators.forEach(iter -> checkArgument(iter.hasNext(), "struct field values cannot be empty"));
+        while (iterators.stream().allMatch(Iterator::hasNext)) {
+            structs.add(iterators.stream().map(Iterator::next).collect(Collectors.toList()));
+        }
+        return structs;
+    }
+
+    private Iterable<List> createNullableTestStructs(Iterable<?>... values)
+    {
+        return insertNullEvery(ThreadLocalRandom.current().nextInt(2, 5), createTestStructs(values));
+    }
+
+    private <T> List<List<T>> createTestArrays(Iterable<T> values)
+    {
+        List<List<T>> arrays = new ArrayList<>();
+        Iterator<T> valuesIter = values.iterator();
+        List<T> array = new ArrayList<>();
+        while (valuesIter.hasNext()) {
+            if (ThreadLocalRandom.current().nextBoolean()) {
+                arrays.add(array);
+                array = new ArrayList<>();
+            }
+            if (ThreadLocalRandom.current().nextInt(10) == 0) {
+                arrays.add(Collections.emptyList());
+            }
+            array.add(valuesIter.next());
+        }
+        return arrays;
+    }
+
+    private <T> Iterable<List<T>> createNullableTestArrays(Iterable<T> values)
+    {
+        return insertNullEvery(ThreadLocalRandom.current().nextInt(2, 5), createTestArrays(values));
+    }
+
+    private <K, V> Iterable<Map<K, V>> createTestMaps(Iterable<K> keys, Iterable<V> values)
+    {
+        List<Map<K, V>> maps = new ArrayList<>();
+        Iterator<K> keysIterator = keys.iterator();
+        Iterator<V> valuesIterator = values.iterator();
+        Map<K, V> map = new HashMap<>();
+        while (keysIterator.hasNext() && valuesIterator.hasNext()) {
+            if (ThreadLocalRandom.current().nextInt(5) == 0) {
+                maps.add(map);
+                map = new HashMap<>();
+            }
+            if (ThreadLocalRandom.current().nextInt(10) == 0) {
+                maps.add(Collections.emptyMap());
+            }
+            map.put(keysIterator.next(), valuesIterator.next());
+        }
+        return maps;
+    }
+
+    private <K, V> Iterable<Map<K, V>> createNullableTestMaps(Iterable<K> keys, Iterable<V> values)
+    {
+        return insertNullEvery(ThreadLocalRandom.current().nextInt(2, 5), createTestMaps(keys, values));
     }
 
     private static Byte intToByte(Integer input)

--- a/presto-hive/src/test/java/com/facebook/presto/hive/parquet/ParquetTester.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/parquet/ParquetTester.java
@@ -13,19 +13,40 @@
  */
 package com.facebook.presto.hive.parquet;
 
-import com.facebook.presto.hive.parquet.reader.ParquetMetadataReader;
-import com.facebook.presto.hive.parquet.reader.ParquetReader;
+import com.facebook.presto.hive.HdfsEnvironment;
+import com.facebook.presto.hive.HiveClientConfig;
+import com.facebook.presto.hive.HiveSessionProperties;
+import com.facebook.presto.hive.HiveStorageFormat;
+import com.facebook.presto.hive.benchmark.FileFormat;
+import com.facebook.presto.hive.parquet.write.MapKeyValuesSchemaConverter;
+import com.facebook.presto.hive.parquet.write.SingleLevelArrayMapKeyValuesSchemaConverter;
+import com.facebook.presto.hive.parquet.write.SingleLevelArraySchemaConverter;
+import com.facebook.presto.hive.parquet.write.TestMapredParquetOutputFormat;
+import com.facebook.presto.spi.ConnectorPageSource;
+import com.facebook.presto.spi.Page;
+import com.facebook.presto.spi.RecordCursor;
+import com.facebook.presto.spi.RecordPageSource;
 import com.facebook.presto.spi.block.Block;
+import com.facebook.presto.spi.type.ArrayType;
+import com.facebook.presto.spi.type.DateType;
+import com.facebook.presto.spi.type.DecimalType;
+import com.facebook.presto.spi.type.MapType;
+import com.facebook.presto.spi.type.SqlDate;
+import com.facebook.presto.spi.type.SqlDecimal;
+import com.facebook.presto.spi.type.SqlTimestamp;
+import com.facebook.presto.spi.type.SqlVarbinary;
+import com.facebook.presto.spi.type.TimestampType;
 import com.facebook.presto.spi.type.Type;
+import com.facebook.presto.testing.TestingConnectorSession;
 import com.google.common.base.Function;
+import com.google.common.base.Joiner;
 import com.google.common.base.Throwables;
 import com.google.common.collect.AbstractIterator;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
+import io.airlift.slice.Slice;
 import io.airlift.units.DataSize;
-import org.apache.hadoop.fs.FSDataInputStream;
-import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hive.ql.exec.FileSinkOperator.RecordWriter;
 import org.apache.hadoop.hive.ql.io.parquet.serde.ParquetHiveSerDe;
@@ -33,32 +54,44 @@ import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector;
 import org.apache.hadoop.hive.serde2.objectinspector.PrimitiveObjectInspector;
 import org.apache.hadoop.hive.serde2.objectinspector.SettableStructObjectInspector;
 import org.apache.hadoop.hive.serde2.objectinspector.StructField;
+import org.apache.hadoop.hive.serde2.typeinfo.TypeInfo;
+import org.apache.hadoop.hive.serde2.typeinfo.TypeInfoUtils;
 import org.apache.hadoop.io.Text;
 import org.apache.hadoop.io.Writable;
 import org.apache.hadoop.mapred.JobConf;
 import org.joda.time.DateTimeZone;
-import parquet.column.ColumnDescriptor;
 import parquet.column.ParquetProperties.WriterVersion;
 import parquet.hadoop.metadata.CompressionCodecName;
-import parquet.hadoop.metadata.FileMetaData;
-import parquet.hadoop.metadata.ParquetMetadata;
 import parquet.schema.MessageType;
 
 import java.io.Closeable;
 import java.io.File;
 import java.io.IOException;
+import java.math.BigInteger;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Properties;
 import java.util.Set;
 
-import static com.facebook.presto.hive.HiveTestUtils.TYPE_MANAGER;
-import static com.facebook.presto.memory.context.AggregatedMemoryContext.newSimpleAggregatedMemoryContext;
-import static com.facebook.presto.testing.TestingConnectorSession.SESSION;
+import static com.facebook.presto.hive.AbstractTestHiveFileFormats.getFieldFromCursor;
+import static com.facebook.presto.hive.HiveTestUtils.createTestHdfsEnvironment;
+import static com.facebook.presto.hive.HiveUtil.isArrayType;
+import static com.facebook.presto.hive.HiveUtil.isMapType;
+import static com.facebook.presto.hive.HiveUtil.isRowType;
+import static com.facebook.presto.hive.HiveUtil.isStructuralType;
+import static com.facebook.presto.spi.type.TimeZoneKey.UTC_KEY;
+import static com.facebook.presto.spi.type.VarbinaryType.VARBINARY;
+import static com.facebook.presto.spi.type.Varchars.isVarcharType;
 import static com.google.common.base.Functions.constant;
 import static com.google.common.collect.Iterables.transform;
 import static io.airlift.units.DataSize.succinctBytes;
+import static java.util.Arrays.stream;
+import static java.util.Collections.singletonList;
 import static org.apache.hadoop.hive.serde2.objectinspector.ObjectInspectorFactory.getStandardStructObjectInspector;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
@@ -75,6 +108,11 @@ import static parquet.hadoop.metadata.CompressionCodecName.UNCOMPRESSED;
 public class ParquetTester
 {
     public static final DateTimeZone HIVE_STORAGE_TIME_ZONE = DateTimeZone.forID("Asia/Katmandu");
+    private static final boolean OPTIMIZED = true;
+    private static final HiveClientConfig HIVE_CLIENT_CONFIG = getHiveClientConfig();
+    private static final HdfsEnvironment HDFS_ENVIRONMENT = createTestHdfsEnvironment(HIVE_CLIENT_CONFIG);
+    private static final TestingConnectorSession SESSION = new TestingConnectorSession(new HiveSessionProperties(HIVE_CLIENT_CONFIG).getSessionProperties());
+    private static final List<String> TEST_COLUMN = singletonList("test");
 
     private Set<CompressionCodecName> compressions = ImmutableSet.of();
 
@@ -108,43 +146,79 @@ public class ParquetTester
         testRoundTrip(columnObjectInspector, writeValues, transform(writeValues, readTransform), parameterType);
     }
 
+    public void testSingleLevelArraySchemaRoundTrip(ObjectInspector objectInspector, Iterable<?> writeValues, Iterable<?> readValues, Type type)
+            throws Exception
+    {
+        ArrayList<TypeInfo> typeInfos = TypeInfoUtils.getTypeInfosFromTypeString(objectInspector.getTypeName());
+        MessageType schema = SingleLevelArraySchemaConverter.convert(TEST_COLUMN, typeInfos);
+        testRoundTrip(objectInspector, writeValues, readValues, type, Optional.of(schema));
+        if (objectInspector.getTypeName().contains("map<")) {
+            schema = SingleLevelArrayMapKeyValuesSchemaConverter.convert(TEST_COLUMN, typeInfos);
+            testRoundTrip(objectInspector, writeValues, readValues, type, Optional.of(schema));
+        }
+    }
+
     public void testRoundTrip(ObjectInspector objectInspector, Iterable<?> writeValues, Iterable<?> readValues, Type type)
             throws Exception
     {
         // just the values
-        testRoundTripType(objectInspector, writeValues, readValues, type);
+        testRoundTripType(singletonList(objectInspector), new Iterable<?>[] {writeValues}, new Iterable<?>[] {readValues}, TEST_COLUMN, singletonList(type), Optional.empty());
 
         // all nulls
-        assertRoundTrip(objectInspector, transform(writeValues, constant(null)), transform(readValues, constant(null)), type);
+        assertRoundTrip(singletonList(objectInspector), new Iterable<?>[] {transform(writeValues, constant(null))},
+                new Iterable<?>[] {transform(writeValues, constant(null))}, TEST_COLUMN, singletonList(type), Optional.empty());
+        if (objectInspector.getTypeName().contains("map<")) {
+            ArrayList<TypeInfo> typeInfos = TypeInfoUtils.getTypeInfosFromTypeString(objectInspector.getTypeName());
+            MessageType schema = MapKeyValuesSchemaConverter.convert(TEST_COLUMN, typeInfos);
+            // just the values
+            testRoundTripType(singletonList(objectInspector), new Iterable<?>[] {writeValues}, new Iterable<?>[] {
+                    readValues}, TEST_COLUMN, singletonList(type), Optional.of(schema));
+
+            // all nulls
+            assertRoundTrip(singletonList(objectInspector), new Iterable<?>[] {transform(writeValues, constant(null))},
+                    new Iterable<?>[] {transform(writeValues, constant(null))}, TEST_COLUMN, singletonList(type), Optional.of(schema));
+        }
     }
 
     public void testRoundTrip(ObjectInspector objectInspector, Iterable<?> writeValues, Iterable<?> readValues, Type type, Optional<MessageType> parquetSchema)
             throws Exception
     {
-        // just the values
-        testRoundTripType(objectInspector, writeValues, readValues, type);
-
-        // all nulls
-        assertRoundTrip(objectInspector, transform(writeValues, constant(null)), transform(readValues, constant(null)), type, parquetSchema);
+        testRoundTrip(singletonList(objectInspector), new Iterable<?>[] {writeValues}, new Iterable<?>[] {readValues}, TEST_COLUMN, singletonList(type), parquetSchema);
     }
 
-    private void testRoundTripType(ObjectInspector objectInspector, Iterable<?> writeValues, Iterable<?> readValues, Type type)
+    public void testRoundTrip(List<ObjectInspector> objectInspectors, Iterable<?>[] writeValues, Iterable<?>[] readValues, List<String> columnNames, List<Type> columnTypes, Optional<MessageType> parquetSchema)
+            throws Exception
+    {
+        // just the values
+        testRoundTripType(objectInspectors, writeValues, readValues, columnNames, columnTypes, parquetSchema);
+
+        // all nulls
+        assertRoundTrip(objectInspectors, transformToNulls(writeValues), transformToNulls(readValues), columnNames, columnTypes, parquetSchema);
+    }
+
+    private void testRoundTripType(List<ObjectInspector> objectInspectors, Iterable<?>[] writeValues, Iterable<?>[] readValues,
+            List<String> columnNames, List<Type> columnTypes, Optional<MessageType> parquetSchema)
             throws Exception
     {
         // forward order
-        assertRoundTrip(objectInspector, writeValues, readValues, type);
+        assertRoundTrip(objectInspectors, writeValues, readValues, columnNames, columnTypes, parquetSchema);
 
         // reverse order
-        assertRoundTrip(objectInspector, reverse(writeValues), reverse(readValues), type);
+        assertRoundTrip(objectInspectors, reverse(writeValues), reverse(readValues), columnNames, columnTypes, parquetSchema);
 
         // forward order with nulls
-        assertRoundTrip(objectInspector, insertNullEvery(5, writeValues), insertNullEvery(5, readValues), type);
+        assertRoundTrip(objectInspectors, insertNullEvery(5, writeValues), insertNullEvery(5, readValues), columnNames, columnTypes, parquetSchema);
 
         // reverse order with nulls
-        assertRoundTrip(objectInspector, insertNullEvery(5, reverse(writeValues)), insertNullEvery(5, reverse(readValues)), type);
+        assertRoundTrip(objectInspectors, insertNullEvery(5, reverse(writeValues)), insertNullEvery(5, reverse(readValues)), columnNames, columnTypes, parquetSchema);
     }
 
-    public void assertRoundTrip(ObjectInspector objectInspector, Iterable<?> writeValues, Iterable<?> readValues, Type type, Optional<MessageType> parquetSchema)
+    void assertRoundTrip(List<ObjectInspector> objectInspectors,
+            Iterable<?>[] writeValues,
+            Iterable<?>[] readValues,
+            List<String> columnNames,
+            List<Type> columnTypes,
+            Optional<MessageType> parquetSchema)
             throws Exception
     {
         for (WriterVersion version : versions) {
@@ -158,69 +232,156 @@ public class ParquetTester
                             jobConf,
                             tempFile.getFile(),
                             compressionCodecName,
-                            objectInspector,
-                            writeValues.iterator(),
+                            createTableProperties(columnNames, objectInspectors),
+                            getStandardStructObjectInspector(columnNames, objectInspectors),
+                            getIterators(writeValues),
                             parquetSchema);
                     assertFileContents(
-                            jobConf,
-                            tempFile,
-                            readValues,
-                            type);
+                            tempFile.getFile(),
+                            getIterators(readValues),
+                            columnNames,
+                            columnTypes);
                 }
             }
         }
     }
 
-    public void assertRoundTrip(ObjectInspector objectInspector, Iterable<?> writeValues, Iterable<?> readValues, Type type)
-            throws Exception
-    {
-        assertRoundTrip(objectInspector, writeValues, readValues, type, Optional.empty());
-    }
-
-    private static void assertFileContents(JobConf jobConf,
-            TempFile tempFile,
-            Iterable<?> expectedValues,
-            Type type)
+    private static void assertFileContents(File dataFile,
+            Iterator<?>[] expectedValues,
+            List<String> columnNames,
+            List<Type> columnTypes)
             throws IOException
     {
-        Path path = new Path(tempFile.getFile().toURI());
-        FileSystem fileSystem = path.getFileSystem(jobConf);
-        ParquetMetadata parquetMetadata = ParquetMetadataReader.readFooter(fileSystem, path, fileSystem.getFileStatus(path).getLen());
-        FileMetaData fileMetaData = parquetMetadata.getFileMetaData();
-        MessageType fileSchema = fileMetaData.getSchema();
+        try (ConnectorPageSource pageSource = getFileFormat().createFileFormatReader(
+                SESSION,
+                HDFS_ENVIRONMENT,
+                dataFile,
+                columnNames,
+                columnTypes)) {
+            if (pageSource instanceof RecordPageSource) {
+                assertRecordCursor(columnTypes, expectedValues, ((RecordPageSource) pageSource).getCursor());
+            }
+            else {
+                assertPageSource(columnTypes, expectedValues, pageSource);
+            }
+            assertFalse(stream(expectedValues).allMatch(Iterator::hasNext));
+        }
+    }
 
-        long size = fileSystem.getFileStatus(path).getLen();
-        FSDataInputStream inputStream = fileSystem.open(path);
-        ParquetDataSource dataSource = new HdfsParquetDataSource(path, size, inputStream);
+    private static void assertPageSource(List<Type> types, Iterator<?>[] valuesByField, ConnectorPageSource pageSource)
+    {
+        Page page;
+        while ((page = pageSource.getNextPage()) != null) {
+            for (int field = 0; field < page.getChannelCount(); field++) {
+                Block block = page.getBlock(field);
+                for (int i = 0; i < block.getPositionCount(); i++) {
+                    assertTrue(valuesByField[field].hasNext());
+                    Object expected = valuesByField[field].next();
+                    Object actual = decodeObject(types.get(field), block, i);
+                    assertEquals(actual, expected);
+                }
+            }
+        }
+    }
 
-        ParquetReader parquetReader = new ParquetReader(fileSchema, fileSchema, parquetMetadata.getBlocks(), dataSource, TYPE_MANAGER, newSimpleAggregatedMemoryContext());
-        assertEquals(parquetReader.getPosition(), 0);
-
-        int rowsProcessed = 0;
-        Iterator<?> iterator = expectedValues.iterator();
-        for (int batchSize = parquetReader.nextBatch(); batchSize >= 0; batchSize = parquetReader.nextBatch()) {
-            ColumnDescriptor columnDescriptor = fileSchema.getColumns().get(0);
-            Block block = parquetReader.readPrimitive(columnDescriptor, type);
-            for (int i = 0; i < batchSize; i++) {
-                assertTrue(iterator.hasNext());
-                Object expected = iterator.next();
-                Object actual = decodeObject(type, block, i);
+    private static void assertRecordCursor(List<Type> types, Iterator<?>[] valuesByField, RecordCursor cursor)
+    {
+        while (cursor.advanceNextPosition()) {
+            for (int field = 0; field < types.size(); field++) {
+                assertTrue(valuesByField[field].hasNext());
+                Object expected = valuesByField[field].next();
+                Object actual = getActualCursorValue(cursor, types.get(field), field);
                 assertEquals(actual, expected);
             }
-            rowsProcessed += batchSize;
-            assertEquals(parquetReader.getPosition(), rowsProcessed);
         }
-        assertFalse(iterator.hasNext());
+    }
 
-        assertEquals(parquetReader.getPosition(), rowsProcessed);
-        parquetReader.close();
+    private static Object getActualCursorValue(RecordCursor cursor, Type type, int field)
+    {
+        Object fieldFromCursor = getFieldFromCursor(cursor, type, field);
+        if (fieldFromCursor == null) {
+            return null;
+        }
+        if (isStructuralType(type)) {
+            Block block = (Block) fieldFromCursor;
+            if (isArrayType(type)) {
+                Type elementType = ((ArrayType) type).getElementType();
+                return toArrayValue(block, elementType);
+            }
+            else if (isMapType(type)) {
+                MapType mapType = (MapType) type;
+                return toMapValue(block, mapType.getKeyType(), mapType.getValueType());
+            }
+            else if (isRowType(type)) {
+                return toRowValue(block, type.getTypeParameters());
+            }
+        }
+        if (type instanceof DecimalType) {
+            DecimalType decimalType = (DecimalType) type;
+            return new SqlDecimal((BigInteger) fieldFromCursor, decimalType.getPrecision(), decimalType.getScale());
+        }
+        if (isVarcharType(type)) {
+            return new String(((Slice) fieldFromCursor).getBytes());
+        }
+        if (VARBINARY.equals(type)) {
+            return new SqlVarbinary(((Slice) fieldFromCursor).getBytes());
+        }
+        if (DateType.DATE.equals(type)) {
+            return new SqlDate(((Long) fieldFromCursor).intValue());
+        }
+        if (TimestampType.TIMESTAMP.equals(type)) {
+            return new SqlTimestamp((long) fieldFromCursor, UTC_KEY);
+        }
+        return fieldFromCursor;
+    }
+
+    private static Map toMapValue(Block mapBlock, Type keyType, Type valueType)
+    {
+        Map<Object, Object> map = new HashMap<>(mapBlock.getPositionCount() * 2);
+        for (int i = 0; i < mapBlock.getPositionCount(); i += 2) {
+            map.put(keyType.getObjectValue(SESSION, mapBlock, i), valueType.getObjectValue(SESSION, mapBlock, i + 1));
+        }
+        return Collections.unmodifiableMap(map);
+    }
+
+    private static List toArrayValue(Block arrayBlock, Type elementType)
+    {
+        List<Object> values = new ArrayList<>();
+        for (int position = 0; position < arrayBlock.getPositionCount(); position++) {
+            values.add(elementType.getObjectValue(SESSION, arrayBlock, position));
+        }
+        return Collections.unmodifiableList(values);
+    }
+
+    private static List toRowValue(Block rowBlock, List<Type> fieldTypes)
+    {
+        List<Object> values = new ArrayList<>(rowBlock.getPositionCount());
+        for (int i = 0; i < rowBlock.getPositionCount(); i++) {
+            values.add(fieldTypes.get(i).getObjectValue(SESSION, rowBlock, i));
+        }
+        return Collections.unmodifiableList(values);
+    }
+
+    private static HiveClientConfig getHiveClientConfig()
+    {
+        HiveClientConfig config = new HiveClientConfig();
+        config.setHiveStorageFormat(HiveStorageFormat.PARQUET);
+        config.setParquetOptimizedReaderEnabled(OPTIMIZED);
+        config.setParquetPredicatePushdownEnabled(OPTIMIZED);
+        return config;
+    }
+
+    private static FileFormat getFileFormat()
+    {
+        return OPTIMIZED ? FileFormat.PRESTO_PARQUET : FileFormat.HIVE_PARQUET;
     }
 
     private static DataSize writeParquetColumn(JobConf jobConf,
             File outputFile,
             CompressionCodecName compressionCodecName,
-            ObjectInspector columnObjectInspector,
-            Iterator<?> values,
+            Properties tableProperties,
+            SettableStructObjectInspector objectInspector,
+            Iterator<?>[] valuesByField,
             Optional<MessageType> parquetSchema)
             throws Exception
     {
@@ -230,17 +391,17 @@ public class ParquetTester
                         new Path(outputFile.toURI()),
                         Text.class,
                         compressionCodecName != UNCOMPRESSED,
-                        createTableProperties("test", columnObjectInspector.getTypeName()),
+                        tableProperties,
                         () -> {});
-        SettableStructObjectInspector objectInspector = createSettableStructObjectInspector("test", columnObjectInspector);
         Object row = objectInspector.create();
         List<StructField> fields = ImmutableList.copyOf(objectInspector.getAllStructFieldRefs());
-        while (values.hasNext()) {
-            Object value = values.next();
-            objectInspector.setStructFieldData(row, fields.get(0), value);
-
+        while (stream(valuesByField).allMatch(Iterator::hasNext)) {
+            for (int field = 0; field < fields.size(); field++) {
+                Object value = valuesByField[field].next();
+                objectInspector.setStructFieldData(row, fields.get(field), value);
+            }
             ParquetHiveSerDe serde = new ParquetHiveSerDe();
-            serde.initialize(jobConf, createTableProperties("test", columnObjectInspector.getTypeName()), null);
+            serde.initialize(jobConf, tableProperties, null);
             Writable record = serde.serialize(row, objectInspector);
             recordWriter.write(record);
         }
@@ -248,16 +409,11 @@ public class ParquetTester
         return succinctBytes(outputFile.length());
     }
 
-    static SettableStructObjectInspector createSettableStructObjectInspector(String name, ObjectInspector objectInspector)
-    {
-        return getStandardStructObjectInspector(ImmutableList.of(name), ImmutableList.of(objectInspector));
-    }
-
-    private static Properties createTableProperties(String name, String type)
+    private static Properties createTableProperties(List<String> columnNames, List<ObjectInspector> objectInspectors)
     {
         Properties orderTableProperties = new Properties();
-        orderTableProperties.setProperty("columns", name);
-        orderTableProperties.setProperty("columns.types", type);
+        orderTableProperties.setProperty("columns", Joiner.on(',').join(columnNames));
+        orderTableProperties.setProperty("columns.types", Joiner.on(',').join(transform(objectInspectors, ObjectInspector::getTypeName)));
         return orderTableProperties;
     }
 
@@ -289,12 +445,34 @@ public class ParquetTester
         }
     }
 
-    private static <T> Iterable<T> reverse(Iterable<T> iterable)
+    private Iterator<?>[] getIterators(Iterable<?>[] values)
     {
-        return Lists.reverse(ImmutableList.copyOf(iterable));
+        return stream(values).map(Iterable::iterator).toArray(size -> new Iterator<?>[size]);
     }
 
-    private static <T> Iterable<T> insertNullEvery(int n, Iterable<T> iterable)
+    private Iterable<?>[] transformToNulls(Iterable<?>[] values)
+    {
+        return stream(values)
+                .map(v -> transform(v, constant(null)))
+                .toArray(size -> new Iterable<?>[size]);
+    }
+
+    private static Iterable<?>[] reverse(Iterable<?>[] iterables)
+    {
+        return stream(iterables)
+                .map(ImmutableList::copyOf)
+                .map(Lists::reverse)
+                .toArray(size -> new Iterable<?>[size]);
+    }
+
+    static Iterable<?>[] insertNullEvery(int n, Iterable<?>[] iterables)
+    {
+        return stream(iterables)
+                .map(itr -> insertNullEvery(n, itr))
+                .toArray(size -> new Iterable<?>[size]);
+    }
+
+    static <T> Iterable<T> insertNullEvery(int n, Iterable<T> iterable)
     {
         return () -> new AbstractIterator<T>()
         {

--- a/presto-hive/src/test/java/com/facebook/presto/hive/parquet/write/MapKeyValuesSchemaConverter.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/parquet/write/MapKeyValuesSchemaConverter.java
@@ -1,0 +1,217 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.hive.parquet.write;
+
+import org.apache.hadoop.hive.ql.io.parquet.serde.ParquetHiveSerDe;
+import org.apache.hadoop.hive.serde.serdeConstants;
+import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector.Category;
+import org.apache.hadoop.hive.serde2.typeinfo.DecimalTypeInfo;
+import org.apache.hadoop.hive.serde2.typeinfo.ListTypeInfo;
+import org.apache.hadoop.hive.serde2.typeinfo.MapTypeInfo;
+import org.apache.hadoop.hive.serde2.typeinfo.StructTypeInfo;
+import org.apache.hadoop.hive.serde2.typeinfo.TypeInfo;
+import org.apache.hadoop.hive.serde2.typeinfo.TypeInfoFactory;
+import parquet.schema.GroupType;
+import parquet.schema.MessageType;
+import parquet.schema.OriginalType;
+import parquet.schema.PrimitiveType.PrimitiveTypeName;
+import parquet.schema.Type;
+import parquet.schema.Type.Repetition;
+import parquet.schema.Types;
+
+import java.util.List;
+
+import static parquet.schema.OriginalType.MAP_KEY_VALUE;
+
+/**
+ * This class is copied from org.apache.hadoop.hive.ql.io.parquet.convert.HiveSchemaConverter
+ * and modified to test maps where MAP_KEY_VALUE is incorrectly used in place of MAP
+ * Backward-compatibility rules described in spec https://github.com/apache/parquet-format/blob/master/LogicalTypes.md#maps
+ */
+public class MapKeyValuesSchemaConverter
+{
+    private MapKeyValuesSchemaConverter()
+    {
+    }
+
+    public static MessageType convert(final List<String> columnNames, final List<TypeInfo> columnTypes)
+    {
+        return new MessageType("hive_schema", convertTypes(columnNames, columnTypes));
+    }
+
+    private static Type[] convertTypes(final List<String> columnNames, final List<TypeInfo> columnTypes)
+    {
+        if (columnNames.size() != columnTypes.size()) {
+            throw new IllegalStateException("Mismatched Hive columns and types. Hive columns names" +
+                    " found : " + columnNames + " . And Hive types found : " + columnTypes);
+        }
+        final Type[] types = new Type[columnNames.size()];
+        for (int i = 0; i < columnNames.size(); ++i) {
+            types[i] = convertType(columnNames.get(i), columnTypes.get(i));
+        }
+        return types;
+    }
+
+    private static Type convertType(final String name, final TypeInfo typeInfo)
+    {
+        return convertType(name, typeInfo, Repetition.OPTIONAL);
+    }
+
+    private static Type convertType(final String name, final TypeInfo typeInfo,
+            final Repetition repetition)
+    {
+        if (typeInfo.getCategory().equals(Category.PRIMITIVE)) {
+            if (typeInfo.equals(TypeInfoFactory.stringTypeInfo)) {
+                return Types.primitive(PrimitiveTypeName.BINARY, repetition).as(OriginalType.UTF8)
+                        .named(name);
+            }
+            else if (typeInfo.equals(TypeInfoFactory.intTypeInfo) ||
+                    typeInfo.equals(TypeInfoFactory.shortTypeInfo) ||
+                    typeInfo.equals(TypeInfoFactory.byteTypeInfo)) {
+                return Types.primitive(PrimitiveTypeName.INT32, repetition).named(name);
+            }
+            else if (typeInfo.equals(TypeInfoFactory.longTypeInfo)) {
+                return Types.primitive(PrimitiveTypeName.INT64, repetition).named(name);
+            }
+            else if (typeInfo.equals(TypeInfoFactory.doubleTypeInfo)) {
+                return Types.primitive(PrimitiveTypeName.DOUBLE, repetition).named(name);
+            }
+            else if (typeInfo.equals(TypeInfoFactory.floatTypeInfo)) {
+                return Types.primitive(PrimitiveTypeName.FLOAT, repetition).named(name);
+            }
+            else if (typeInfo.equals(TypeInfoFactory.booleanTypeInfo)) {
+                return Types.primitive(PrimitiveTypeName.BOOLEAN, repetition).named(name);
+            }
+            else if (typeInfo.equals(TypeInfoFactory.binaryTypeInfo)) {
+                return Types.primitive(PrimitiveTypeName.BINARY, repetition).named(name);
+            }
+            else if (typeInfo.equals(TypeInfoFactory.timestampTypeInfo)) {
+                return Types.primitive(PrimitiveTypeName.INT96, repetition).named(name);
+            }
+            else if (typeInfo.equals(TypeInfoFactory.voidTypeInfo)) {
+                throw new UnsupportedOperationException("Void type not implemented");
+            }
+            else if (typeInfo.getTypeName().toLowerCase().startsWith(
+                    serdeConstants.CHAR_TYPE_NAME)) {
+                return Types.optional(PrimitiveTypeName.BINARY).as(OriginalType.UTF8).named(name);
+            }
+            else if (typeInfo.getTypeName().toLowerCase().startsWith(
+                    serdeConstants.VARCHAR_TYPE_NAME)) {
+                return Types.optional(PrimitiveTypeName.BINARY).as(OriginalType.UTF8).named(name);
+            }
+            else if (typeInfo instanceof DecimalTypeInfo) {
+                DecimalTypeInfo decimalTypeInfo = (DecimalTypeInfo) typeInfo;
+                int prec = decimalTypeInfo.precision();
+                int scale = decimalTypeInfo.scale();
+                int bytes = ParquetHiveSerDe.PRECISION_TO_BYTE_COUNT[prec - 1];
+                return Types.optional(PrimitiveTypeName.FIXED_LEN_BYTE_ARRAY).length(bytes).as(OriginalType.DECIMAL).scale(scale).precision(prec).named(name);
+            }
+            else if (typeInfo.equals(TypeInfoFactory.dateTypeInfo)) {
+                return Types.primitive(PrimitiveTypeName.INT32, repetition).as(OriginalType.DATE).named(name);
+            }
+            else if (typeInfo.equals(TypeInfoFactory.unknownTypeInfo)) {
+                throw new UnsupportedOperationException("Unknown type not implemented");
+            }
+            else {
+                throw new IllegalArgumentException("Unknown type: " + typeInfo);
+            }
+        }
+        else if (typeInfo.getCategory().equals(Category.LIST)) {
+            return convertArrayType(name, (ListTypeInfo) typeInfo);
+        }
+        else if (typeInfo.getCategory().equals(Category.STRUCT)) {
+            return convertStructType(name, (StructTypeInfo) typeInfo);
+        }
+        else if (typeInfo.getCategory().equals(Category.MAP)) {
+            return convertMapType(name, (MapTypeInfo) typeInfo);
+        }
+        else if (typeInfo.getCategory().equals(Category.UNION)) {
+            throw new UnsupportedOperationException("Union type not implemented");
+        }
+        else {
+            throw new IllegalArgumentException("Unknown type: " + typeInfo);
+        }
+    }
+
+    // An optional group containing a repeated anonymous group "bag", containing
+    // 1 anonymous element "array_element"
+    private static GroupType convertArrayType(final String name, final ListTypeInfo typeInfo)
+    {
+        final TypeInfo subType = typeInfo.getListElementTypeInfo();
+        return listWrapper(name, OriginalType.LIST, new GroupType(Repetition.REPEATED,
+                ParquetHiveSerDe.ARRAY.toString(), convertType("array_element", subType)));
+    }
+
+    // An optional group containing multiple elements
+    private static GroupType convertStructType(final String name, final StructTypeInfo typeInfo)
+    {
+        final List<String> columnNames = typeInfo.getAllStructFieldNames();
+        final List<TypeInfo> columnTypes = typeInfo.getAllStructFieldTypeInfos();
+        return new GroupType(Repetition.OPTIONAL, name, convertTypes(columnNames, columnTypes));
+    }
+
+    // An optional group containing a repeated anonymous group "map", containing
+    // 2 elements: "key", "value"
+    private static GroupType convertMapType(final String name, final MapTypeInfo typeInfo)
+    {
+        final Type keyType = convertType(ParquetHiveSerDe.MAP_KEY.toString(),
+                typeInfo.getMapKeyTypeInfo(), Repetition.REQUIRED);
+        final Type valueType = convertType(ParquetHiveSerDe.MAP_VALUE.toString(),
+                typeInfo.getMapValueTypeInfo());
+        return mapType(Repetition.OPTIONAL, name, "map", keyType, valueType);
+    }
+
+    public static GroupType mapType(Repetition repetition, String alias, String mapAlias, Type keyType, Type valueType)
+    {
+        //support projection only on key of a map
+        if (valueType == null) {
+            return listWrapper(
+                    repetition,
+                    alias,
+                    MAP_KEY_VALUE,
+                    new GroupType(
+                            Repetition.REPEATED,
+                            mapAlias,
+                            keyType));
+        }
+        else {
+            if (!valueType.getName().equals("value")) {
+                throw new RuntimeException(valueType.getName() + " should be value");
+            }
+            return listWrapper(
+                    repetition,
+                    alias,
+                    MAP_KEY_VALUE,
+                    new GroupType(
+                            Repetition.REPEATED,
+                            mapAlias,
+                            keyType,
+                            valueType));
+        }
+    }
+
+    private static GroupType listWrapper(Repetition repetition, String alias, OriginalType originalType, Type nested)
+    {
+        if (!nested.isRepetition(Repetition.REPEATED)) {
+            throw new IllegalArgumentException("Nested type should be repeated: " + nested);
+        }
+        return new GroupType(repetition, alias, originalType, nested);
+    }
+
+    private static GroupType listWrapper(final String name, final OriginalType originalType,
+            final GroupType groupType)
+    {
+        return new GroupType(Repetition.OPTIONAL, name, originalType, groupType);
+    }
+}

--- a/presto-hive/src/test/java/com/facebook/presto/hive/parquet/write/SingleLevelArrayMapKeyValuesSchemaConverter.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/parquet/write/SingleLevelArrayMapKeyValuesSchemaConverter.java
@@ -1,0 +1,231 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.hive.parquet.write;
+
+import org.apache.hadoop.hive.ql.io.parquet.serde.ParquetHiveSerDe;
+import org.apache.hadoop.hive.serde.serdeConstants;
+import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector.Category;
+import org.apache.hadoop.hive.serde2.typeinfo.DecimalTypeInfo;
+import org.apache.hadoop.hive.serde2.typeinfo.ListTypeInfo;
+import org.apache.hadoop.hive.serde2.typeinfo.MapTypeInfo;
+import org.apache.hadoop.hive.serde2.typeinfo.StructTypeInfo;
+import org.apache.hadoop.hive.serde2.typeinfo.TypeInfo;
+import org.apache.hadoop.hive.serde2.typeinfo.TypeInfoFactory;
+import parquet.schema.GroupType;
+import parquet.schema.MessageType;
+import parquet.schema.OriginalType;
+import parquet.schema.PrimitiveType.PrimitiveTypeName;
+import parquet.schema.Type;
+import parquet.schema.Type.Repetition;
+import parquet.schema.Types;
+
+import java.util.List;
+
+import static parquet.schema.OriginalType.MAP_KEY_VALUE;
+
+/**
+ * This class is copied from org.apache.hadoop.hive.ql.io.parquet.convert.HiveSchemaConverter
+ * and modified to test Array Schema without wrapping anonymous group "bag".
+ * Additionally, there is a schema modification in maps where MAP_KEY_VALUE is incorrectly used in place of MAP
+ * Backward-compatibility rules described in spec https://github.com/apache/parquet-format/blob/master/LogicalTypes.md#lists
+ */
+public class SingleLevelArrayMapKeyValuesSchemaConverter
+{
+    private SingleLevelArrayMapKeyValuesSchemaConverter()
+    {
+    }
+
+    public static MessageType convert(final List<String> columnNames, final List<TypeInfo> columnTypes)
+    {
+        return new MessageType("hive_schema", convertTypes(columnNames, columnTypes));
+    }
+
+    private static Type[] convertTypes(final List<String> columnNames, final List<TypeInfo> columnTypes)
+    {
+        if (columnNames.size() != columnTypes.size()) {
+            throw new IllegalStateException("Mismatched Hive columns and types. Hive columns names" +
+                    " found : " + columnNames + " . And Hive types found : " + columnTypes);
+        }
+        final Type[] types = new Type[columnNames.size()];
+        for (int i = 0; i < columnNames.size(); ++i) {
+            types[i] = convertType(columnNames.get(i), columnTypes.get(i));
+        }
+        return types;
+    }
+
+    private static Type convertType(final String name, final TypeInfo typeInfo)
+    {
+        return convertType(name, typeInfo, Repetition.OPTIONAL);
+    }
+
+    private static Type convertType(final String name, final TypeInfo typeInfo,
+            final Repetition repetition)
+    {
+        if (typeInfo.getCategory().equals(Category.PRIMITIVE)) {
+            if (typeInfo.equals(TypeInfoFactory.stringTypeInfo)) {
+                return Types.primitive(PrimitiveTypeName.BINARY, repetition).as(OriginalType.UTF8)
+                        .named(name);
+            }
+            else if (typeInfo.equals(TypeInfoFactory.intTypeInfo) ||
+                    typeInfo.equals(TypeInfoFactory.shortTypeInfo) ||
+                    typeInfo.equals(TypeInfoFactory.byteTypeInfo)) {
+                return Types.primitive(PrimitiveTypeName.INT32, repetition).named(name);
+            }
+            else if (typeInfo.equals(TypeInfoFactory.longTypeInfo)) {
+                return Types.primitive(PrimitiveTypeName.INT64, repetition).named(name);
+            }
+            else if (typeInfo.equals(TypeInfoFactory.doubleTypeInfo)) {
+                return Types.primitive(PrimitiveTypeName.DOUBLE, repetition).named(name);
+            }
+            else if (typeInfo.equals(TypeInfoFactory.floatTypeInfo)) {
+                return Types.primitive(PrimitiveTypeName.FLOAT, repetition).named(name);
+            }
+            else if (typeInfo.equals(TypeInfoFactory.booleanTypeInfo)) {
+                return Types.primitive(PrimitiveTypeName.BOOLEAN, repetition).named(name);
+            }
+            else if (typeInfo.equals(TypeInfoFactory.binaryTypeInfo)) {
+                return Types.primitive(PrimitiveTypeName.BINARY, repetition).named(name);
+            }
+            else if (typeInfo.equals(TypeInfoFactory.timestampTypeInfo)) {
+                return Types.primitive(PrimitiveTypeName.INT96, repetition).named(name);
+            }
+            else if (typeInfo.equals(TypeInfoFactory.voidTypeInfo)) {
+                throw new UnsupportedOperationException("Void type not implemented");
+            }
+            else if (typeInfo.getTypeName().toLowerCase().startsWith(
+                    serdeConstants.CHAR_TYPE_NAME)) {
+                if (repetition == Repetition.OPTIONAL) {
+                    return Types.optional(PrimitiveTypeName.BINARY).as(OriginalType.UTF8).named(name);
+                }
+                else {
+                    return Types.repeated(PrimitiveTypeName.BINARY).as(OriginalType.UTF8).named(name);
+                }
+            }
+            else if (typeInfo.getTypeName().toLowerCase().startsWith(
+                    serdeConstants.VARCHAR_TYPE_NAME)) {
+                if (repetition == Repetition.OPTIONAL) {
+                    return Types.optional(PrimitiveTypeName.BINARY).as(OriginalType.UTF8).named(name);
+                }
+                else {
+                    return Types.repeated(PrimitiveTypeName.BINARY).as(OriginalType.UTF8).named(name);
+                }
+            }
+            else if (typeInfo instanceof DecimalTypeInfo) {
+                DecimalTypeInfo decimalTypeInfo = (DecimalTypeInfo) typeInfo;
+                int prec = decimalTypeInfo.precision();
+                int scale = decimalTypeInfo.scale();
+                int bytes = ParquetHiveSerDe.PRECISION_TO_BYTE_COUNT[prec - 1];
+                if (repetition == Repetition.OPTIONAL) {
+                    return Types.optional(PrimitiveTypeName.FIXED_LEN_BYTE_ARRAY).length(bytes).as(OriginalType.DECIMAL).scale(scale).precision(prec).named(name);
+                }
+                else {
+                    return Types.repeated(PrimitiveTypeName.FIXED_LEN_BYTE_ARRAY).length(bytes).as(OriginalType.DECIMAL).scale(scale).precision(prec).named(name);
+                }
+            }
+            else if (typeInfo.equals(TypeInfoFactory.dateTypeInfo)) {
+                return Types.primitive(PrimitiveTypeName.INT32, repetition).as(OriginalType.DATE).named(name);
+            }
+            else if (typeInfo.equals(TypeInfoFactory.unknownTypeInfo)) {
+                throw new UnsupportedOperationException("Unknown type not implemented");
+            }
+            else {
+                throw new IllegalArgumentException("Unknown type: " + typeInfo);
+            }
+        }
+        else if (typeInfo.getCategory().equals(Category.LIST)) {
+            return convertArrayType(name, (ListTypeInfo) typeInfo, repetition);
+        }
+        else if (typeInfo.getCategory().equals(Category.STRUCT)) {
+            return convertStructType(name, (StructTypeInfo) typeInfo, repetition);
+        }
+        else if (typeInfo.getCategory().equals(Category.MAP)) {
+            return convertMapType(name, (MapTypeInfo) typeInfo, repetition);
+        }
+        else if (typeInfo.getCategory().equals(Category.UNION)) {
+            throw new UnsupportedOperationException("Union type not implemented");
+        }
+        else {
+            throw new IllegalArgumentException("Unknown type: " + typeInfo);
+        }
+    }
+
+    // 1 anonymous element "array_element"
+    private static GroupType convertArrayType(final String name, final ListTypeInfo typeInfo, final Repetition repetition)
+    {
+        final TypeInfo subType = typeInfo.getListElementTypeInfo();
+        return listWrapper(name, OriginalType.LIST, convertType("array_element", subType, Repetition.REPEATED), repetition);
+    }
+
+    // An optional group containing multiple elements
+    private static GroupType convertStructType(final String name, final StructTypeInfo typeInfo, final Repetition repetition)
+    {
+        final List<String> columnNames = typeInfo.getAllStructFieldNames();
+        final List<TypeInfo> columnTypes = typeInfo.getAllStructFieldTypeInfos();
+        return new GroupType(repetition, name, convertTypes(columnNames, columnTypes));
+    }
+
+    // An optional group containing a repeated anonymous group "map", containing
+    // 2 elements: "key", "value"
+    private static GroupType convertMapType(final String name, final MapTypeInfo typeInfo, final Repetition repetition)
+    {
+        final Type keyType = convertType(ParquetHiveSerDe.MAP_KEY.toString(),
+                typeInfo.getMapKeyTypeInfo(), Repetition.REQUIRED);
+        final Type valueType = convertType(ParquetHiveSerDe.MAP_VALUE.toString(),
+                typeInfo.getMapValueTypeInfo());
+        return mapType(repetition, name, "map", keyType, valueType);
+    }
+
+    public static GroupType mapType(Repetition repetition, String alias, String mapAlias, Type keyType, Type valueType)
+    {
+        //support projection only on key of a map
+        if (valueType == null) {
+            return listWrapper(
+                    repetition,
+                    alias,
+                    MAP_KEY_VALUE,
+                    new GroupType(
+                            Repetition.REPEATED,
+                            mapAlias,
+                            keyType));
+        }
+        else {
+            if (!valueType.getName().equals("value")) {
+                throw new RuntimeException(valueType.getName() + " should be value");
+            }
+            return listWrapper(
+                    repetition,
+                    alias,
+                    MAP_KEY_VALUE,
+                    new GroupType(
+                            Repetition.REPEATED,
+                            mapAlias,
+                            keyType,
+                            valueType));
+        }
+    }
+
+    private static GroupType listWrapper(Repetition repetition, String alias, OriginalType originalType, Type nested)
+    {
+        if (!nested.isRepetition(Repetition.REPEATED)) {
+            throw new IllegalArgumentException("Nested type should be repeated: " + nested);
+        }
+        return new GroupType(repetition, alias, originalType, nested);
+    }
+
+    private static GroupType listWrapper(final String name, final OriginalType originalType,
+            final Type elementType, final Repetition repetition)
+    {
+        return new GroupType(repetition, name, originalType, elementType);
+    }
+}

--- a/presto-hive/src/test/java/com/facebook/presto/hive/parquet/write/SingleLevelArraySchemaConverter.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/parquet/write/SingleLevelArraySchemaConverter.java
@@ -1,0 +1,192 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.hive.parquet.write;
+
+import org.apache.hadoop.hive.ql.io.parquet.serde.ParquetHiveSerDe;
+import org.apache.hadoop.hive.serde.serdeConstants;
+import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector.Category;
+import org.apache.hadoop.hive.serde2.typeinfo.DecimalTypeInfo;
+import org.apache.hadoop.hive.serde2.typeinfo.ListTypeInfo;
+import org.apache.hadoop.hive.serde2.typeinfo.MapTypeInfo;
+import org.apache.hadoop.hive.serde2.typeinfo.StructTypeInfo;
+import org.apache.hadoop.hive.serde2.typeinfo.TypeInfo;
+import org.apache.hadoop.hive.serde2.typeinfo.TypeInfoFactory;
+import parquet.schema.ConversionPatterns;
+import parquet.schema.GroupType;
+import parquet.schema.MessageType;
+import parquet.schema.OriginalType;
+import parquet.schema.PrimitiveType.PrimitiveTypeName;
+import parquet.schema.Type;
+import parquet.schema.Type.Repetition;
+import parquet.schema.Types;
+
+import java.util.List;
+
+/**
+ * This class is copied from org.apache.hadoop.hive.ql.io.parquet.convert.HiveSchemaConverter
+ * and modified to test Array Schema without wrapping anonymous group "bag".
+ * Backward-compatibility rules described in spec https://github.com/apache/parquet-format/blob/master/LogicalTypes.md#lists
+ */
+public class SingleLevelArraySchemaConverter
+{
+    private SingleLevelArraySchemaConverter()
+    {
+    }
+
+    public static MessageType convert(final List<String> columnNames, final List<TypeInfo> columnTypes)
+    {
+        return new MessageType("hive_schema", convertTypes(columnNames, columnTypes));
+    }
+
+    private static Type[] convertTypes(final List<String> columnNames, final List<TypeInfo> columnTypes)
+    {
+        if (columnNames.size() != columnTypes.size()) {
+            throw new IllegalStateException("Mismatched Hive columns and types. Hive columns names" +
+                    " found : " + columnNames + " . And Hive types found : " + columnTypes);
+        }
+        final Type[] types = new Type[columnNames.size()];
+        for (int i = 0; i < columnNames.size(); ++i) {
+            types[i] = convertType(columnNames.get(i), columnTypes.get(i));
+        }
+        return types;
+    }
+
+    private static Type convertType(final String name, final TypeInfo typeInfo)
+    {
+        return convertType(name, typeInfo, Repetition.OPTIONAL);
+    }
+
+    private static Type convertType(final String name, final TypeInfo typeInfo,
+            final Repetition repetition)
+    {
+        if (typeInfo.getCategory().equals(Category.PRIMITIVE)) {
+            if (typeInfo.equals(TypeInfoFactory.stringTypeInfo)) {
+                return Types.primitive(PrimitiveTypeName.BINARY, repetition).as(OriginalType.UTF8)
+                        .named(name);
+            }
+            else if (typeInfo.equals(TypeInfoFactory.intTypeInfo) ||
+                    typeInfo.equals(TypeInfoFactory.shortTypeInfo) ||
+                    typeInfo.equals(TypeInfoFactory.byteTypeInfo)) {
+                return Types.primitive(PrimitiveTypeName.INT32, repetition).named(name);
+            }
+            else if (typeInfo.equals(TypeInfoFactory.longTypeInfo)) {
+                return Types.primitive(PrimitiveTypeName.INT64, repetition).named(name);
+            }
+            else if (typeInfo.equals(TypeInfoFactory.doubleTypeInfo)) {
+                return Types.primitive(PrimitiveTypeName.DOUBLE, repetition).named(name);
+            }
+            else if (typeInfo.equals(TypeInfoFactory.floatTypeInfo)) {
+                return Types.primitive(PrimitiveTypeName.FLOAT, repetition).named(name);
+            }
+            else if (typeInfo.equals(TypeInfoFactory.booleanTypeInfo)) {
+                return Types.primitive(PrimitiveTypeName.BOOLEAN, repetition).named(name);
+            }
+            else if (typeInfo.equals(TypeInfoFactory.binaryTypeInfo)) {
+                return Types.primitive(PrimitiveTypeName.BINARY, repetition).named(name);
+            }
+            else if (typeInfo.equals(TypeInfoFactory.timestampTypeInfo)) {
+                return Types.primitive(PrimitiveTypeName.INT96, repetition).named(name);
+            }
+            else if (typeInfo.equals(TypeInfoFactory.voidTypeInfo)) {
+                throw new UnsupportedOperationException("Void type not implemented");
+            }
+            else if (typeInfo.getTypeName().toLowerCase().startsWith(
+                    serdeConstants.CHAR_TYPE_NAME)) {
+                if (repetition == Repetition.OPTIONAL) {
+                    return Types.optional(PrimitiveTypeName.BINARY).as(OriginalType.UTF8).named(name);
+                }
+                else {
+                    return Types.repeated(PrimitiveTypeName.BINARY).as(OriginalType.UTF8).named(name);
+                }
+            }
+            else if (typeInfo.getTypeName().toLowerCase().startsWith(
+                    serdeConstants.VARCHAR_TYPE_NAME)) {
+                if (repetition == Repetition.OPTIONAL) {
+                    return Types.optional(PrimitiveTypeName.BINARY).as(OriginalType.UTF8).named(name);
+                }
+                else {
+                    return Types.repeated(PrimitiveTypeName.BINARY).as(OriginalType.UTF8).named(name);
+                }
+            }
+            else if (typeInfo instanceof DecimalTypeInfo) {
+                DecimalTypeInfo decimalTypeInfo = (DecimalTypeInfo) typeInfo;
+                int prec = decimalTypeInfo.precision();
+                int scale = decimalTypeInfo.scale();
+                int bytes = ParquetHiveSerDe.PRECISION_TO_BYTE_COUNT[prec - 1];
+                if (repetition == Repetition.OPTIONAL) {
+                    return Types.optional(PrimitiveTypeName.FIXED_LEN_BYTE_ARRAY).length(bytes).as(OriginalType.DECIMAL).scale(scale).precision(prec).named(name);
+                }
+                else {
+                    return Types.repeated(PrimitiveTypeName.FIXED_LEN_BYTE_ARRAY).length(bytes).as(OriginalType.DECIMAL).scale(scale).precision(prec).named(name);
+                }
+            }
+            else if (typeInfo.equals(TypeInfoFactory.dateTypeInfo)) {
+                return Types.primitive(PrimitiveTypeName.INT32, repetition).as(OriginalType.DATE).named(name);
+            }
+            else if (typeInfo.equals(TypeInfoFactory.unknownTypeInfo)) {
+                throw new UnsupportedOperationException("Unknown type not implemented");
+            }
+            else {
+                throw new IllegalArgumentException("Unknown type: " + typeInfo);
+            }
+        }
+        else if (typeInfo.getCategory().equals(Category.LIST)) {
+            return convertArrayType(name, (ListTypeInfo) typeInfo, repetition);
+        }
+        else if (typeInfo.getCategory().equals(Category.STRUCT)) {
+            return convertStructType(name, (StructTypeInfo) typeInfo, repetition);
+        }
+        else if (typeInfo.getCategory().equals(Category.MAP)) {
+            return convertMapType(name, (MapTypeInfo) typeInfo, repetition);
+        }
+        else if (typeInfo.getCategory().equals(Category.UNION)) {
+            throw new UnsupportedOperationException("Union type not implemented");
+        }
+        else {
+            throw new IllegalArgumentException("Unknown type: " + typeInfo);
+        }
+    }
+
+    // 1 anonymous element "array_element"
+    private static GroupType convertArrayType(final String name, final ListTypeInfo typeInfo, final Repetition repetition)
+    {
+        final TypeInfo subType = typeInfo.getListElementTypeInfo();
+        return listWrapper(name, OriginalType.LIST, convertType("array_element", subType, Repetition.REPEATED), repetition);
+    }
+
+    // An optional group containing multiple elements
+    private static GroupType convertStructType(final String name, final StructTypeInfo typeInfo, final Repetition repetition)
+    {
+        final List<String> columnNames = typeInfo.getAllStructFieldNames();
+        final List<TypeInfo> columnTypes = typeInfo.getAllStructFieldTypeInfos();
+        return new GroupType(repetition, name, convertTypes(columnNames, columnTypes));
+    }
+
+    // An optional group containing a repeated anonymous group "map", containing
+    // 2 elements: "key", "value"
+    private static GroupType convertMapType(final String name, final MapTypeInfo typeInfo, final Repetition repetition)
+    {
+        final Type keyType = convertType(ParquetHiveSerDe.MAP_KEY.toString(),
+                typeInfo.getMapKeyTypeInfo(), Repetition.REQUIRED);
+        final Type valueType = convertType(ParquetHiveSerDe.MAP_VALUE.toString(),
+                typeInfo.getMapValueTypeInfo());
+        return ConversionPatterns.mapType(repetition, name, keyType, valueType);
+    }
+
+    private static GroupType listWrapper(final String name, final OriginalType originalType,
+            final Type elementType, final Repetition repetition)
+    {
+        return new GroupType(repetition, name, originalType, elementType);
+    }
+}

--- a/presto-hive/src/test/java/com/facebook/presto/hive/parquet/write/TestDataWritableWriteSupport.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/parquet/write/TestDataWritableWriteSupport.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.hive.parquet.write;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hive.ql.io.parquet.write.DataWritableWriteSupport;
+import org.apache.hadoop.hive.serde2.io.ParquetHiveRecord;
+import parquet.hadoop.api.WriteSupport;
+import parquet.io.api.RecordConsumer;
+import parquet.schema.MessageType;
+
+import java.util.HashMap;
+
+/**
+ * This class is copied from org.apache.hadoop.hive.ql.io.parquet.write.DataWritableWriteSupport
+ * and extended to support empty arrays and maps (HIVE-13632).
+ */
+class TestDataWritableWriteSupport
+        extends WriteSupport<ParquetHiveRecord>
+{
+    private TestDataWritableWriter writer;
+    private MessageType schema;
+
+    @Override
+    public WriteContext init(final Configuration configuration)
+    {
+        schema = DataWritableWriteSupport.getSchema(configuration);
+        return new WriteContext(schema, new HashMap<>());
+    }
+
+    @Override
+    public void prepareForWrite(final RecordConsumer recordConsumer)
+    {
+        writer = new TestDataWritableWriter(recordConsumer, schema);
+    }
+
+    @Override
+    public void write(final ParquetHiveRecord record)
+    {
+        writer.write(record);
+    }
+}

--- a/presto-hive/src/test/java/com/facebook/presto/hive/parquet/write/TestDataWritableWriter.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/parquet/write/TestDataWritableWriter.java
@@ -1,0 +1,412 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.hive.parquet.write;
+
+import io.airlift.log.Logger;
+import org.apache.hadoop.hive.common.type.HiveDecimal;
+import org.apache.hadoop.hive.ql.io.parquet.serde.ParquetHiveSerDe;
+import org.apache.hadoop.hive.ql.io.parquet.timestamp.NanoTimeUtils;
+import org.apache.hadoop.hive.ql.io.parquet.write.DataWritableWriter;
+import org.apache.hadoop.hive.serde2.io.DateWritable;
+import org.apache.hadoop.hive.serde2.io.ParquetHiveRecord;
+import org.apache.hadoop.hive.serde2.objectinspector.ListObjectInspector;
+import org.apache.hadoop.hive.serde2.objectinspector.MapObjectInspector;
+import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector;
+import org.apache.hadoop.hive.serde2.objectinspector.PrimitiveObjectInspector;
+import org.apache.hadoop.hive.serde2.objectinspector.StructField;
+import org.apache.hadoop.hive.serde2.objectinspector.StructObjectInspector;
+import org.apache.hadoop.hive.serde2.objectinspector.primitive.BinaryObjectInspector;
+import org.apache.hadoop.hive.serde2.objectinspector.primitive.BooleanObjectInspector;
+import org.apache.hadoop.hive.serde2.objectinspector.primitive.ByteObjectInspector;
+import org.apache.hadoop.hive.serde2.objectinspector.primitive.DateObjectInspector;
+import org.apache.hadoop.hive.serde2.objectinspector.primitive.DoubleObjectInspector;
+import org.apache.hadoop.hive.serde2.objectinspector.primitive.FloatObjectInspector;
+import org.apache.hadoop.hive.serde2.objectinspector.primitive.HiveCharObjectInspector;
+import org.apache.hadoop.hive.serde2.objectinspector.primitive.HiveVarcharObjectInspector;
+import org.apache.hadoop.hive.serde2.objectinspector.primitive.IntObjectInspector;
+import org.apache.hadoop.hive.serde2.objectinspector.primitive.LongObjectInspector;
+import org.apache.hadoop.hive.serde2.objectinspector.primitive.ShortObjectInspector;
+import org.apache.hadoop.hive.serde2.objectinspector.primitive.StringObjectInspector;
+import org.apache.hadoop.hive.serde2.objectinspector.primitive.TimestampObjectInspector;
+import org.apache.hadoop.hive.serde2.typeinfo.DecimalTypeInfo;
+import parquet.io.api.Binary;
+import parquet.io.api.RecordConsumer;
+import parquet.schema.GroupType;
+import parquet.schema.OriginalType;
+import parquet.schema.Type;
+
+import java.sql.Date;
+import java.sql.Timestamp;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * This class is copied from org.apache.hadoop.hive.ql.io.parquet.write.DataWritableWriter
+ * and extended to support empty arrays and maps (HIVE-13632).
+ * Additionally, there is a support for arrays without include an inner element layer and
+ * support for maps where  MAP_KEY_VALUE is incorrectly used in place of MAP
+ * for backward-compatibility rules testing (https://github.com/apache/parquet-format/blob/master/LogicalTypes.md#lists)
+ */
+public class TestDataWritableWriter
+{
+    private static final Logger log = Logger.get(DataWritableWriter.class);
+    private final RecordConsumer recordConsumer;
+    private final GroupType schema;
+
+    public TestDataWritableWriter(final RecordConsumer recordConsumer, final GroupType schema)
+    {
+        this.recordConsumer = recordConsumer;
+        this.schema = schema;
+    }
+
+    /**
+     * It writes all record values to the Parquet RecordConsumer.
+     *
+     * @param record Contains the record that are going to be written.
+     */
+    public void write(final ParquetHiveRecord record)
+    {
+        if (record != null) {
+            recordConsumer.startMessage();
+            try {
+                writeGroupFields(record.getObject(), record.getObjectInspector(), schema);
+            }
+            catch (RuntimeException e) {
+                String errorMessage = "Parquet record is malformed: " + e.getMessage();
+                log.error(errorMessage, e);
+                throw new RuntimeException(errorMessage, e);
+            }
+            recordConsumer.endMessage();
+        }
+    }
+
+    /**
+     * It writes all the fields contained inside a group to the RecordConsumer.
+     *
+     * @param value The list of values contained in the group.
+     * @param inspector The object inspector used to get the correct value type.
+     * @param type Type that contains information about the group schema.
+     */
+    private void writeGroupFields(final Object value, final StructObjectInspector inspector, final GroupType type)
+    {
+        if (value != null) {
+            List<? extends StructField> fields = inspector.getAllStructFieldRefs();
+            List<Object> fieldValuesList = inspector.getStructFieldsDataAsList(value);
+
+            for (int i = 0; i < type.getFieldCount(); i++) {
+                Type fieldType = type.getType(i);
+                String fieldName = fieldType.getName();
+                Object fieldValue = fieldValuesList.get(i);
+
+                if (fieldValue != null) {
+                    ObjectInspector fieldInspector = fields.get(i).getFieldObjectInspector();
+                    recordConsumer.startField(fieldName, i);
+                    writeValue(fieldValue, fieldInspector, fieldType);
+                    recordConsumer.endField(fieldName, i);
+                }
+            }
+        }
+    }
+
+    /**
+     * It writes the field value to the Parquet RecordConsumer. It detects the field type, and calls
+     * the correct write function.
+     *
+     * @param value The writable object that contains the value.
+     * @param inspector The object inspector used to get the correct value type.
+     * @param type Type that contains information about the type schema.
+     */
+    private void writeValue(final Object value, final ObjectInspector inspector, final Type type)
+    {
+        if (type.isPrimitive()) {
+            checkInspectorCategory(inspector, ObjectInspector.Category.PRIMITIVE);
+            writePrimitive(value, (PrimitiveObjectInspector) inspector);
+        }
+        else {
+            GroupType groupType = type.asGroupType();
+            OriginalType originalType = type.getOriginalType();
+
+            if (originalType != null && originalType.equals(OriginalType.LIST)) {
+                checkInspectorCategory(inspector, ObjectInspector.Category.LIST);
+                writeArray(value, (ListObjectInspector) inspector, groupType);
+            }
+            else if (originalType != null && (originalType.equals(OriginalType.MAP) || originalType.equals(OriginalType.MAP_KEY_VALUE))) {
+                checkInspectorCategory(inspector, ObjectInspector.Category.MAP);
+                writeMap(value, (MapObjectInspector) inspector, groupType);
+            }
+            else {
+                checkInspectorCategory(inspector, ObjectInspector.Category.STRUCT);
+                writeGroup(value, (StructObjectInspector) inspector, groupType);
+            }
+        }
+    }
+
+    /**
+     * Checks that an inspector matches the category indicated as a parameter.
+     *
+     * @param inspector The object inspector to check
+     * @param category The category to match
+     * @throws IllegalArgumentException if inspector does not match the category
+     */
+    private void checkInspectorCategory(ObjectInspector inspector, ObjectInspector.Category category)
+    {
+        if (!inspector.getCategory().equals(category)) {
+            throw new IllegalArgumentException("Invalid data type: expected " + category
+                    + " type, but found: " + inspector.getCategory());
+        }
+    }
+
+    /**
+     * It writes a group type and all its values to the Parquet RecordConsumer.
+     * This is used only for optional and required groups.
+     *
+     * @param value Object that contains the group values.
+     * @param inspector The object inspector used to get the correct value type.
+     * @param type Type that contains information about the group schema.
+     */
+    private void writeGroup(final Object value, final StructObjectInspector inspector, final GroupType type)
+    {
+        recordConsumer.startGroup();
+        writeGroupFields(value, inspector, type);
+        recordConsumer.endGroup();
+    }
+
+    /**
+     * It writes a list type and its array elements to the Parquet RecordConsumer.
+     * This is called when the original type (LIST) is detected by writeValue()/
+     * This function assumes the following schema:
+     * optional group arrayCol (LIST) {
+     * repeated group array {
+     * optional TYPE array_element;
+     * }
+     * }
+     *
+     * @param value The object that contains the array values.
+     * @param inspector The object inspector used to get the correct value type.
+     * @param type Type that contains information about the group (LIST) schema.
+     */
+    private void writeArray(final Object value, final ListObjectInspector inspector, final GroupType type)
+    {
+        if (type.getType(0).isPrimitive()) {
+            writeSingleLevelArray(value, inspector, type);
+            return;
+        }
+        // Get the internal array structure
+        GroupType repeatedType = type.getType(0).asGroupType();
+        if (repeatedType.getOriginalType() != null || repeatedType.getFieldCount() > 1) {
+            writeSingleLevelArray(value, inspector, type);
+            return;
+        }
+        recordConsumer.startGroup();
+
+        List<?> arrayValues = inspector.getList(value);
+        if (!arrayValues.isEmpty()) {
+            recordConsumer.startField(repeatedType.getName(), 0);
+            ObjectInspector elementInspector = inspector.getListElementObjectInspector();
+
+            Type elementType = repeatedType.getType(0);
+            String elementName = elementType.getName();
+
+            for (Object element : arrayValues) {
+                recordConsumer.startGroup();
+                if (element != null) {
+                    recordConsumer.startField(elementName, 0);
+                    writeValue(element, elementInspector, elementType);
+                    recordConsumer.endField(elementName, 0);
+                }
+                recordConsumer.endGroup();
+            }
+
+            recordConsumer.endField(repeatedType.getName(), 0);
+        }
+        recordConsumer.endGroup();
+    }
+
+    private void writeSingleLevelArray(final Object value, final ListObjectInspector inspector, final GroupType type)
+    {
+        // Get the internal array structure
+        Type elementType = type.getType(0);
+
+        recordConsumer.startGroup();
+
+        List<?> arrayValues = inspector.getList(value);
+        if (!arrayValues.isEmpty()) {
+            recordConsumer.startField(elementType.getName(), 0);
+            ObjectInspector elementInspector = inspector.getListElementObjectInspector();
+
+            for (Object element : arrayValues) {
+                if (element == null) {
+                    throw new IllegalArgumentException("Array elements are requires in given schema definition");
+                }
+                writeValue(element, elementInspector, elementType);
+            }
+
+            recordConsumer.endField(elementType.getName(), 0);
+        }
+        recordConsumer.endGroup();
+    }
+
+    /**
+     * It writes a map type and its key-pair values to the Parquet RecordConsumer.
+     * This is called when the original type (MAP) is detected by writeValue().
+     * This function assumes the following schema:
+     * optional group mapCol (MAP) {
+     * repeated group map (MAP_KEY_VALUE) {
+     * required TYPE key;
+     * optional TYPE value;
+     * }
+     * }
+     *
+     * @param value The object that contains the map key-values.
+     * @param inspector The object inspector used to get the correct value type.
+     * @param type Type that contains information about the group (MAP) schema.
+     */
+    private void writeMap(final Object value, final MapObjectInspector inspector, final GroupType type)
+    {
+        // Get the internal map structure (MAP_KEY_VALUE)
+        GroupType repeatedType = type.getType(0).asGroupType();
+
+        recordConsumer.startGroup();
+        Map<?, ?> mapValues = inspector.getMap(value);
+        if (mapValues != null && mapValues.size() > 0) {
+            recordConsumer.startField(repeatedType.getName(), 0);
+
+            Type keyType = repeatedType.getType(0);
+            String keyName = keyType.getName();
+            ObjectInspector keyInspector = inspector.getMapKeyObjectInspector();
+
+            Type valuetype = repeatedType.getType(1);
+            String valueName = valuetype.getName();
+            ObjectInspector valueInspector = inspector.getMapValueObjectInspector();
+
+            for (Map.Entry<?, ?> keyValue : mapValues.entrySet()) {
+                recordConsumer.startGroup();
+                if (keyValue != null) {
+                    // write key element
+                    Object keyElement = keyValue.getKey();
+                    recordConsumer.startField(keyName, 0);
+                    writeValue(keyElement, keyInspector, keyType);
+                    recordConsumer.endField(keyName, 0);
+
+                    // write value element
+                    Object valueElement = keyValue.getValue();
+                    if (valueElement != null) {
+                        recordConsumer.startField(valueName, 1);
+                        writeValue(valueElement, valueInspector, valuetype);
+                        recordConsumer.endField(valueName, 1);
+                    }
+                }
+                recordConsumer.endGroup();
+            }
+
+            recordConsumer.endField(repeatedType.getName(), 0);
+        }
+        recordConsumer.endGroup();
+    }
+
+    /**
+     * It writes the primitive value to the Parquet RecordConsumer.
+     *
+     * @param value The object that contains the primitive value.
+     * @param inspector The object inspector used to get the correct value type.
+     */
+    private void writePrimitive(final Object value, final PrimitiveObjectInspector inspector)
+    {
+        if (value == null) {
+            return;
+        }
+
+        switch (inspector.getPrimitiveCategory()) {
+            case VOID:
+                return;
+            case DOUBLE:
+                recordConsumer.addDouble(((DoubleObjectInspector) inspector).get(value));
+                break;
+            case BOOLEAN:
+                recordConsumer.addBoolean(((BooleanObjectInspector) inspector).get(value));
+                break;
+            case FLOAT:
+                recordConsumer.addFloat(((FloatObjectInspector) inspector).get(value));
+                break;
+            case BYTE:
+                recordConsumer.addInteger(((ByteObjectInspector) inspector).get(value));
+                break;
+            case INT:
+                recordConsumer.addInteger(((IntObjectInspector) inspector).get(value));
+                break;
+            case LONG:
+                recordConsumer.addLong(((LongObjectInspector) inspector).get(value));
+                break;
+            case SHORT:
+                recordConsumer.addInteger(((ShortObjectInspector) inspector).get(value));
+                break;
+            case STRING:
+                String v = ((StringObjectInspector) inspector).getPrimitiveJavaObject(value);
+                recordConsumer.addBinary(Binary.fromString(v));
+                break;
+            case CHAR:
+                String vChar = ((HiveCharObjectInspector) inspector).getPrimitiveJavaObject(value).getStrippedValue();
+                recordConsumer.addBinary(Binary.fromString(vChar));
+                break;
+            case VARCHAR:
+                String vVarchar = ((HiveVarcharObjectInspector) inspector).getPrimitiveJavaObject(value).getValue();
+                recordConsumer.addBinary(Binary.fromString(vVarchar));
+                break;
+            case BINARY:
+                byte[] vBinary = ((BinaryObjectInspector) inspector).getPrimitiveJavaObject(value);
+                recordConsumer.addBinary(Binary.fromByteArray(vBinary));
+                break;
+            case TIMESTAMP:
+                Timestamp ts = ((TimestampObjectInspector) inspector).getPrimitiveJavaObject(value);
+                recordConsumer.addBinary(NanoTimeUtils.getNanoTime(ts, false).toBinary());
+                break;
+            case DECIMAL:
+                HiveDecimal vDecimal = ((HiveDecimal) inspector.getPrimitiveJavaObject(value));
+                DecimalTypeInfo decTypeInfo = (DecimalTypeInfo) inspector.getTypeInfo();
+                recordConsumer.addBinary(decimalToBinary(vDecimal, decTypeInfo));
+                break;
+            case DATE:
+                Date vDate = ((DateObjectInspector) inspector).getPrimitiveJavaObject(value);
+                recordConsumer.addInteger(DateWritable.dateToDays(vDate));
+                break;
+            default:
+                throw new IllegalArgumentException("Unsupported primitive data type: " + inspector.getPrimitiveCategory());
+        }
+    }
+
+    private Binary decimalToBinary(final HiveDecimal hiveDecimal, final DecimalTypeInfo decimalTypeInfo)
+    {
+        int prec = decimalTypeInfo.precision();
+        int scale = decimalTypeInfo.scale();
+        byte[] decimalBytes = hiveDecimal.setScale(scale).unscaledValue().toByteArray();
+
+        // Estimated number of bytes needed.
+        int precToBytes = ParquetHiveSerDe.PRECISION_TO_BYTE_COUNT[prec - 1];
+        if (precToBytes == decimalBytes.length) {
+            // No padding needed.
+            return Binary.fromByteArray(decimalBytes);
+        }
+
+        byte[] tgt = new byte[precToBytes];
+        if (hiveDecimal.signum() == -1) {
+            // For negative number, initializing bits to 1
+            for (int i = 0; i < precToBytes; i++) {
+                tgt[i] |= 0xFF;
+            }
+        }
+
+        System.arraycopy(decimalBytes, 0, tgt, precToBytes - decimalBytes.length, decimalBytes.length); // Padding leading zeroes/ones.
+        return Binary.fromByteArray(tgt);
+    }
+}

--- a/presto-hive/src/test/java/com/facebook/presto/hive/parquet/write/TestMapredParquetOutputFormat.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/parquet/write/TestMapredParquetOutputFormat.java
@@ -11,7 +11,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.facebook.presto.hive.parquet;
+package com.facebook.presto.hive.parquet.write;
 
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hive.ql.exec.FileSinkOperator;
@@ -20,6 +20,7 @@ import org.apache.hadoop.hive.ql.io.parquet.write.DataWritableWriteSupport;
 import org.apache.hadoop.io.Writable;
 import org.apache.hadoop.mapred.JobConf;
 import org.apache.hadoop.util.Progressable;
+import parquet.hadoop.ParquetOutputFormat;
 import parquet.schema.MessageType;
 
 import java.io.IOException;
@@ -42,6 +43,7 @@ public class TestMapredParquetOutputFormat
 
     public TestMapredParquetOutputFormat(Optional<MessageType> schema)
     {
+        super(new ParquetOutputFormat<>(new TestDataWritableWriteSupport()));
         this.schema = requireNonNull(schema, "schema is null");
     }
 


### PR DESCRIPTION
This PR intends to fix the complex type handling in Hive optimized parquet reader. It includes two changesets:
 - [**55c5f66**]: a patch cherry-picked from upstream PR that fixes reading Parquet complex type
 - [**158035a**]: a patch fixes find the column by name using the alternative name(with "_") in twitter dataset