### PR TITLE
Filter presto statement source when bypassing authentication

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/server/security/SecurityConfig.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/security/SecurityConfig.java
@@ -33,9 +33,8 @@ public class SecurityConfig
 
     private List<AuthenticationType> authenticationTypes = ImmutableList.of();
 
-    private String httpAuthenticationPathRegex = "^\b$";
-
-    private boolean allowByPass;
+    private String httpAuthenticationPathRegex = "^\\b$";
+    private String statementSourceByPassRegex = "^\\b$";
 
     public enum AuthenticationType
     {
@@ -86,16 +85,16 @@ public class SecurityConfig
         return this;
     }
 
-    public boolean getAllowByPass()
+    public String getStatementSourceByPassRegex()
     {
-        return allowByPass;
+        return statementSourceByPassRegex;
     }
 
-    @Config("http-server.authentication.allow-by-pass")
-    @ConfigDescription("Allow authentication by pass")
-    public SecurityConfig setAllowByPass(boolean allowByPass)
+    @Config("http-server.statement.source.allow-by-pass-authentication")
+    @ConfigDescription("Regex of the statement source that allows bypass authentication")
+    public SecurityConfig setStatementSourceByPassRegex(String regex)
     {
-        this.allowByPass = allowByPass;
+        this.statementSourceByPassRegex = regex;
         return this;
     }
 }

--- a/presto-main/src/test/java/com/facebook/presto/server/security/TestSecurityConfig.java
+++ b/presto-main/src/test/java/com/facebook/presto/server/security/TestSecurityConfig.java
@@ -30,8 +30,8 @@ public class TestSecurityConfig
     {
         ConfigAssertions.assertRecordedDefaults(ConfigAssertions.recordDefaults(SecurityConfig.class)
                 .setAuthenticationTypes("")
-                .setHttpAuthenticationPathRegex("^\b$")
-                .setAllowByPass(false));
+                .setHttpAuthenticationPathRegex("^\\b$")
+                .setStatementSourceByPassRegex("^\\b$"));
     }
 
     @Test
@@ -40,13 +40,13 @@ public class TestSecurityConfig
         Map<String, String> properties = new ImmutableMap.Builder<String, String>()
                 .put("http-server.authentication.type", "KERBEROS,PASSWORD")
                 .put("http-server.http.authentication.path.regex", "^/v1/statement")
-                .put("http-server.authentication.allow-by-pass", "true")
+                .put("http-server.statement.source.allow-by-pass-authentication", "odbc|presto-jdbc")
                 .build();
 
         SecurityConfig expected = new SecurityConfig()
                 .setAuthenticationTypes(ImmutableList.of(KERBEROS, PASSWORD))
                 .setHttpAuthenticationPathRegex("^/v1/statement")
-                .setAllowByPass(true);
+                .setStatementSourceByPassRegex("odbc|presto-jdbc");
 
         ConfigAssertions.assertFullMapping(properties, expected);
     }


### PR DESCRIPTION
Only allow certain client source to bypass the authentication. This will be used to force some client to config credentials.