### PR TITLE
expose jmx metrix to /v1/jmx/mbean

### DIFF
--- a/presto-twitter-gateway/pom.xml
+++ b/presto-twitter-gateway/pom.xml
@@ -100,6 +100,11 @@
 
         <dependency>
             <groupId>io.airlift</groupId>
+            <artifactId>jmx-http</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
             <artifactId>concurrent</artifactId>
         </dependency>
 

--- a/presto-twitter-gateway/src/main/java/com/twitter/presto/gateway/PrestoGateway.java
+++ b/presto-twitter-gateway/src/main/java/com/twitter/presto/gateway/PrestoGateway.java
@@ -19,6 +19,7 @@ import io.airlift.bootstrap.Bootstrap;
 import io.airlift.event.client.EventModule;
 import io.airlift.http.server.HttpServerModule;
 import io.airlift.jaxrs.JaxrsModule;
+import io.airlift.jmx.JmxHttpModule;
 import io.airlift.jmx.JmxModule;
 import io.airlift.json.JsonModule;
 import io.airlift.log.LogJmxModule;
@@ -40,6 +41,7 @@ public class PrestoGateway
                 .add(new JaxrsModule(true))
                 .add(new MBeanModule())
                 .add(new JmxModule())
+                .add(new JmxHttpModule())
                 .add(new LogJmxModule())
                 .add(new TraceTokenModule())
                 .add(new EventModule())


### PR DESCRIPTION
As what we did for presto-server, add JmxHttpModule to presto-twitter-gateway