### PR TITLE
Add service account key file auth in BqStreamer

### DIFF
--- a/twitter-eventlistener-plugin/pom.xml
+++ b/twitter-eventlistener-plugin/pom.xml
@@ -119,7 +119,7 @@
         <dependency>
             <groupId>com.google.cloud</groupId>
             <artifactId>google-cloud-bigquery</artifactId>
-            <version>1.55.0</version>
+            <version>1.84.0</version>
             <exclusions>
                 <exclusion>
                     <groupId>com.fasterxml.jackson.core</groupId>
@@ -144,6 +144,46 @@
                 <exclusion>
                     <groupId>org.slf4j</groupId>
                     <artifactId>jcl-over-slf4j</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>javax.annotation</groupId>
+                    <artifactId>javax.annotation-api</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.google.errorprone</groupId>
+                    <artifactId>error_prone_annotations</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.google.j2objc</groupId>
+                    <artifactId>j2objc-annotations</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>com.google.auth</groupId>
+            <artifactId>google-auth-library-oauth2-http</artifactId>
+            <version>0.16.2</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.google.guava</groupId>
+                    <artifactId>guava</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-core</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.google.errorprone</groupId>
+                    <artifactId>error_prone_annotations</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.google.j2objc</groupId>
+                    <artifactId>j2objc-annotations</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>commons-logging</groupId>
+                    <artifactId>commons-logging</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>

--- a/twitter-eventlistener-plugin/src/main/java/com/twitter/presto/plugin/eventlistener/TwitterEventListenerConfig.java
+++ b/twitter-eventlistener-plugin/src/main/java/com/twitter/presto/plugin/eventlistener/TwitterEventListenerConfig.java
@@ -29,6 +29,7 @@ public class TwitterEventListenerConfig
     private String knowledgeBaseFile;
     private String scribeCategory;
     private String bqTableFullName;
+    private String serviceAccountKeyFile;
 
     public String getSlackConfigFile()
     {
@@ -135,6 +136,18 @@ public class TwitterEventListenerConfig
     public TwitterEventListenerConfig setBqTableFullName(String bqTableFullName)
     {
         this.bqTableFullName = bqTableFullName;
+        return this;
+    }
+
+    public String getServiceAccountKeyFile()
+    {
+        return serviceAccountKeyFile;
+    }
+
+    @Config("event-listener.bq-json-key-file")
+    public TwitterEventListenerConfig setServiceAccountKeyFile(String serviceAccountKeyFile)
+    {
+        this.serviceAccountKeyFile = serviceAccountKeyFile;
         return this;
     }
 }

--- a/twitter-eventlistener-plugin/src/test/java/com/twitter/presto/plugin/eventlistener/TestTwitterEventListenerConfig.java
+++ b/twitter-eventlistener-plugin/src/test/java/com/twitter/presto/plugin/eventlistener/TestTwitterEventListenerConfig.java
@@ -34,7 +34,9 @@ public class TestTwitterEventListenerConfig
                 .setSlackNotificationTemplateFile(null)
                 .setKnowledgeBaseFile(null)
                 .setSlackUri(null)
-                .setSlackUsers(null));
+                .setSlackUsers(null)
+                .setBqTableFullName(null)
+                .setServiceAccountKeyFile(null));
     }
 
     @Test
@@ -49,6 +51,8 @@ public class TestTwitterEventListenerConfig
                 .put("event-listener.slack-notification-template-file", "/etc/config/notification.json")
                 .put("event-listener.slack-uri", "https://slack.com")
                 .put("event-listener.slack-users", "user1|user2")
+                .put("event-listener.bq-table-full-name", "test-bq")
+                .put("event-listener.bq-json-key-file", "key.json")
                 .build();
 
         TwitterEventListenerConfig expected = new TwitterEventListenerConfig()
@@ -59,7 +63,9 @@ public class TestTwitterEventListenerConfig
                 .setSlackHttpProxy(HostAndPort.fromString("localhost:1008"))
                 .setSlackNotificationTemplateFile("/etc/config/notification.json")
                 .setSlackUri(URI.create("https://slack.com"))
-                .setSlackUsers("user1|user2");
+                .setSlackUsers("user1|user2")
+                .setBqTableFullName("test-bq")
+                .setServiceAccountKeyFile("key.json");
 
         ConfigAssertions.assertFullMapping(properties, expected);
     }


### PR DESCRIPTION
Currently, the BqStreamer uses default instance which will fall back to authentication using VM metadata. When Presto moves to GKE, it needs to use service account JSON key to authenticate with BigQuery.

This patch adds key-file based authentication in `BqStreamer`