### PR TITLE
Fix race of http client in router and Refactoring

### DIFF
--- a/presto-router/src/main/java/io/prestosql/router/RouterModule.java
+++ b/presto-router/src/main/java/io/prestosql/router/RouterModule.java
@@ -20,7 +20,9 @@ import io.airlift.units.Duration;
 import io.prestosql.router.cluster.ClusterManager;
 import io.prestosql.router.cluster.ClusterStatusResource;
 import io.prestosql.router.cluster.ClusterStatusTracker;
-import io.prestosql.router.cluster.ForQueryTracker;
+import io.prestosql.router.cluster.ForClusterInfoTracker;
+import io.prestosql.router.cluster.ForQueryInfoTracker;
+import io.prestosql.router.cluster.RemoteInfoFactory;
 
 import static io.airlift.configuration.ConfigBinder.configBinder;
 import static io.airlift.http.client.HttpClientBinder.httpClientBinder;
@@ -38,8 +40,14 @@ public class RouterModule
         configBinder(binder).bindConfig(RouterConfig.class);
 
         binder.bind(ClusterManager.class).in(Scopes.SINGLETON);
+        binder.bind(RemoteInfoFactory.class).in(Scopes.SINGLETON);
 
-        httpClientBinder(binder).bindHttpClient("query-tracker", ForQueryTracker.class)
+        httpClientBinder(binder).bindHttpClient("query-tracker", ForQueryInfoTracker.class)
+                .withConfigDefaults(config -> {
+                    config.setIdleTimeout(new Duration(30, SECONDS));
+                    config.setRequestTimeout(new Duration(10, SECONDS));
+                });
+        httpClientBinder(binder).bindHttpClient("query-tracker", ForClusterInfoTracker.class)
                 .withConfigDefaults(config -> {
                     config.setIdleTimeout(new Duration(30, SECONDS));
                     config.setRequestTimeout(new Duration(10, SECONDS));

--- a/presto-router/src/main/java/io/prestosql/router/cluster/ForClusterInfoTracker.java
+++ b/presto-router/src/main/java/io/prestosql/router/cluster/ForClusterInfoTracker.java
@@ -26,6 +26,6 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 @Retention(RUNTIME)
 @Target({FIELD, PARAMETER, METHOD})
 @Qualifier
-public @interface ForQueryTracker
+public @interface ForClusterInfoTracker
 {
 }

--- a/presto-router/src/main/java/io/prestosql/router/cluster/ForQueryInfoTracker.java
+++ b/presto-router/src/main/java/io/prestosql/router/cluster/ForQueryInfoTracker.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.router.cluster;
+
+import javax.inject.Qualifier;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+@Retention(RUNTIME)
+@Target({FIELD, PARAMETER, METHOD})
+@Qualifier
+public @interface ForQueryInfoTracker
+{
+}

--- a/presto-router/src/main/java/io/prestosql/router/cluster/RemoteInfoFactory.java
+++ b/presto-router/src/main/java/io/prestosql/router/cluster/RemoteInfoFactory.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.router.cluster;
+
+import io.airlift.http.client.HttpClient;
+
+import javax.inject.Inject;
+
+import java.net.URI;
+
+import static io.airlift.http.client.HttpUriBuilder.uriBuilderFrom;
+import static java.util.Objects.requireNonNull;
+
+public class RemoteInfoFactory
+{
+    private static final String QUERY_INFO = "/v1/query";
+    private static final String CLUSTER_INFO = "/v1/cluster";
+    private final HttpClient clusterInfoHttpClient;
+    private final HttpClient queryInfoHttpClient;
+
+    @Inject
+    public RemoteInfoFactory(
+            @ForClusterInfoTracker HttpClient clusterInfoHttpClient,
+            @ForQueryInfoTracker HttpClient queryInfoHttpClient)
+    {
+        this.clusterInfoHttpClient = requireNonNull(clusterInfoHttpClient, "Http client for cluster info is null");
+        this.queryInfoHttpClient = requireNonNull(queryInfoHttpClient, "Http client for cluster info is null");
+    }
+
+    public RemoteQueryInfo createRemoteQueryInfo(URI uri)
+    {
+        return new RemoteQueryInfo(clusterInfoHttpClient, uriBuilderFrom(uri).appendPath(QUERY_INFO).build());
+    }
+
+    public RemoteClusterInfo createRemoteClusterInfo(URI uri)
+    {
+        return new RemoteClusterInfo(queryInfoHttpClient, uriBuilderFrom(uri).appendPath(CLUSTER_INFO).build());
+    }
+}


### PR DESCRIPTION
Eliminate the race condition of http client to fix early EOF exception on the https connection between router and sub-coordinator.
Involving a factory to create and control the life-cycle of remote tracker and http-client.