### PR TITLE
Fix Travis CI running time (50min) limit exceptions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,8 @@ env:
     - WEBUI_CHECKS=true
     - TEST_SPECIFIC_MODULES=presto-tests
     - TEST_SPECIFIC_MODULES=presto-tests TEST_FLAGS="-P ci-only"
+    - TEST_SPECIFIC_MODULES=presto-tests TEST_FLAGS="-P ci-only-2"
+    - TEST_SPECIFIC_MODULES=presto-tests TEST_FLAGS="-P ci-only-3"
     - TEST_SPECIFIC_MODULES=presto-raptor
     - TEST_SPECIFIC_MODULES=presto-accumulo
     - TEST_SPECIFIC_MODULES=presto-cassandra
@@ -21,12 +23,17 @@ env:
     - TEST_SPECIFIC_MODULES=presto-hive TEST_FLAGS="-P test-hive-recoverable-grouped-execution"
     - TEST_SPECIFIC_MODULES=presto-hive TEST_FLAGS="-P test-hive-pushdown-filter-queries"
     - TEST_SPECIFIC_MODULES=presto-hive TEST_FLAGS="-P test-hive-parquet"
+    - TEST_SPECIFIC_MODULES=presto-hive TEST_FLAGS="-P test-hive-distributed-queries"
+    - TEST_SPECIFIC_MODULES=presto-hive TEST_FLAGS="-P test-hive-integration-smoke"
     - TEST_SPECIFIC_MODULES=presto-main
     - TEST_SPECIFIC_MODULES=presto-mongodb
-    - TEST_OTHER_MODULES=!presto-tests,!presto-raptor,!presto-accumulo,!presto-cassandra,!presto-hive,!presto-kudu,!presto-docs,!presto-server,!presto-server-rpm,!presto-main,!presto-mongodb
+    - TEST_SPECIFIC_MODULES=presto-thrift-connector
+    - TEST_SPECIFIC_MODULES=presto-orc
+    - TEST_OTHER_MODULES=!presto-tests,!presto-raptor,!presto-accumulo,!presto-cassandra,!presto-hive,!presto-kudu,!presto-docs,!presto-server,!presto-server-rpm,!presto-main,!presto-mongodb,!presto-thrift-connector,!presto-orc
     - PRODUCT_TESTS_BASIC_ENVIRONMENT=true
     - PRODUCT_TESTS_SPECIFIC_ENVIRONMENT=true
     - PRODUCT_TESTS_SPECIFIC_ENVIRONMENT_2=true
+    - PRODUCT_TESTS_SPECIFIC_ENVIRONMENT_3=true
     - HIVE_TESTS=true
     - KUDU_TESTS=true
 
@@ -55,7 +62,7 @@ install:
       ./mvnw install $MAVEN_FAST_INSTALL -pl '!presto-docs,!presto-server,!presto-server-rpm'
     fi
   - |
-    if [[ -v PRODUCT_TESTS_BASIC_ENVIRONMENT || -v PRODUCT_TESTS_SPECIFIC_ENVIRONMENT || -v PRODUCT_TESTS_SPECIFIC_ENVIRONMENT_2 ]]; then
+    if [[ -v PRODUCT_TESTS_BASIC_ENVIRONMENT || -v PRODUCT_TESTS_SPECIFIC_ENVIRONMENT || -v PRODUCT_TESTS_SPECIFIC_ENVIRONMENT_2 || -v PRODUCT_TESTS_SPECIFIC_ENVIRONMENT_3 ]]; then
       ./mvnw install $MAVEN_FAST_INSTALL -pl '!presto-docs,!presto-server-rpm'
     fi
   - |
@@ -94,7 +101,7 @@ script:
     fi
   - |
     if [[ -v TEST_SPECIFIC_MODULES ]]; then
-      ./mvnw test $MAVEN_SKIP_CHECKS_AND_DOCS -B -pl $TEST_SPECIFIC_MODULES $TEST_FLAGS
+      travis_wait 50 ./mvnw test $MAVEN_SKIP_CHECKS_AND_DOCS -B -pl $TEST_SPECIFIC_MODULES $TEST_FLAGS
     fi
   - |
     if [[ -v TEST_OTHER_MODULES ]]; then
@@ -163,7 +170,7 @@ script:
       presto-product-tests/bin/run_on_docker.sh \
         singlenode-cassandra -g cassandra
     fi
-    if [[ -v PRODUCT_TESTS_SPECIFIC_ENVIRONMENT ]]; then
+    if [[ -v PRODUCT_TESTS_SPECIFIC_ENVIRONMENT_3 ]]; then
       presto-product-tests/bin/run_on_docker.sh \
         multinode-tls-kerberos -g cli,group-by,join,tls
     fi

--- a/presto-hive/pom.xml
+++ b/presto-hive/pom.xml
@@ -387,6 +387,10 @@
                                 <exclude>**/TestHiveRecoverableGroupedExecution.java</exclude>
                                 <exclude>**/TestHivePushdownFilterQueries.java</exclude>
                                 <exclude>**/TestParquetDistributedQueries.java</exclude>
+
+                                <!-- Exclude long running -->
+                                <exclude>**/TestHiveDistributedQueries.java</exclude>
+                                <exclude>**/TestHiveIntegrationSmokeTest.java</exclude>
                             </excludes>
                         </configuration>
                     </plugin>
@@ -468,6 +472,38 @@
                         <configuration>
                             <includes>
                                 <include>**/TestParquetDistributedQueries.java</include>
+                            </includes>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>test-hive-distributed-queries</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration>
+                            <includes>
+                                <include>**/TestHiveDistributedQueries.java</include>
+                            </includes>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>test-hive-integration-smoke</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration>
+                            <includes>
+                                <include>**/TestHiveIntegrationSmokeTest.java</include>
                             </includes>
                         </configuration>
                     </plugin>

--- a/presto-tests/pom.xml
+++ b/presto-tests/pom.xml
@@ -221,6 +221,9 @@
                         <exclude>**/TestDistributedQueriesNoHashGeneration.java</exclude>
                         <exclude>**/TestLocalQueries.java</exclude>
                         <exclude>**/TestNonIterativeDistributedQueries.java</exclude>
+                        <exclude>**/TestDistributedQueriesIndexed.java</exclude>
+                        <exclude>**/TestDistributedSpilledQueries.java</exclude>
+                        <exclude>**/TestTpchDistributedQueries.java</exclude>
                     </excludes>
                 </configuration>
             </plugin>
@@ -255,7 +258,44 @@
                             <includes>
                                 <include>**/TestDistributedQueriesNoHashGeneration.java</include>
                                 <include>**/TestLocalQueries.java</include>
+                            </includes>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+
+        <profile>
+            <id>ci-only-2</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration>
+                            <excludes combine.self="override" />
+                            <includes>
                                 <include>**/TestNonIterativeDistributedQueries.java</include>
+                            </includes>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+
+        <profile>
+            <id>ci-only-3</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration>
+                            <excludes combine.self="override" />
+                            <includes>
+                                <include>**/TestDistributedQueriesIndexed.java</include>
+                                <include>**/TestDistributedSpilledQueries.java</include>
+                                <include>**/TestTpchDistributedQueries.java</include>
                             </includes>
                         </configuration>
                     </plugin>


### PR DESCRIPTION
This PR does following two changes:
1. Breaks long running jobs into smaller ones so that it won't violate 50 minutes limitation. Also we want jobs to have some margin to take care of running time variations. 
2. For jobs that doesn't return result for 10 minutes, Travis will kill them. We use travis_wait 50 to make sure those jobs doesn't error out.