### PR TITLE
Port event listener for query logging

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,12 +44,28 @@ cache:
   yarn: true
   directories:
     - $HOME/.m2/repository
+    - $HOME/.thrift
 
 services:
   - docker
 
 git:
   quiet: true
+
+before_install:
+  - |
+    if [[ ! -e $HOME/.thrift/bin/thrift ]]; then
+      sudo apt-get install libboost-dev libboost-test-dev libboost-program-options-dev libboost-filesystem-dev libboost-thread-dev libevent-dev automake libtool flex bison pkg-config g++ libssl-dev
+      wget https://www.apache.org/dist/thrift/0.9.3/thrift-0.9.3.tar.gz
+      tar xfz thrift-0.9.3.tar.gz
+      cd thrift-0.9.3 && ./configure --without-cpp --without-c_glib --without-python --without-ruby --without-php --without-erlang --without-go --without-nodejs -q --prefix=$HOME/.thrift
+      sudo make install > thrift_make_install.log
+      cd ..
+    fi
+  - |
+    if [[ ! -e /usr/local/bin/thrift ]]; then
+      sudo ln -s $HOME/.thrift/bin/thrift /usr/local/bin/thrift
+    fi
 
 install:
   - ./mvnw -v

--- a/pom.xml
+++ b/pom.xml
@@ -141,6 +141,7 @@
         <module>presto-elasticsearch</module>
         <module>presto-sql-function</module>
         <module>presto-expressions</module>
+        <module>twitter-eventlistener-plugin</module>
     </modules>
 
     <dependencyManagement>

--- a/twitter-eventlistener-plugin/pom.xml
+++ b/twitter-eventlistener-plugin/pom.xml
@@ -1,0 +1,177 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <groupId>com.facebook.presto</groupId>
+        <artifactId>presto-root</artifactId>
+        <version>0.228</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>twitter-event-listener</artifactId>
+    <description>Twitter Event Listener</description>
+    <packaging>presto-plugin</packaging>
+
+    <properties>
+        <air.main.basedir>${project.parent.basedir}</air.main.basedir>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-spi</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>bootstrap</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>configuration</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>log</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>units</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.google.inject</groupId>
+            <artifactId>guice</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>javax.inject</groupId>
+            <artifactId>javax.inject</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.glassfish</groupId>
+            <artifactId>javax.json</artifactId>
+            <version>1.0.4</version>
+        </dependency>
+
+        <!-- twitter deps -->
+        <dependency>
+            <groupId>com.twitter</groupId>
+            <artifactId>util-logging_2.10</artifactId>
+            <version>6.34.0</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>commons-logging</groupId>
+                    <artifactId>commons-logging</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.thrift</groupId>
+            <artifactId>libthrift</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.scala-lang</groupId>
+            <artifactId>scala-library</artifactId>
+            <version>2.10.6</version>
+        </dependency>
+
+        <!-- for testing -->
+        <dependency>
+            <groupId>org.testng</groupId>
+            <artifactId>testng</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>testing</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>http-server</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>jaxrs</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>node</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>javax.ws.rs</groupId>
+            <artifactId>javax.ws.rs-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-tests</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-main</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-tpch</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.thrift.tools</groupId>
+                <artifactId>maven-thrift-plugin</artifactId>
+                <version>0.1.11</version>
+                <configuration>
+                    <thriftExecutable>/usr/local/bin/thrift</thriftExecutable>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>thrift-sources</id>
+                        <phase>generate-sources</phase>
+                        <goals>
+                            <goal>compile</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>thrift-test-sources</id>
+                        <phase>generate-test-sources</phase>
+                        <goals>
+                            <goal>testCompile</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/twitter-eventlistener-plugin/src/main/java/com/twitter/presto/plugin/eventlistener/TwitterEventHandler.java
+++ b/twitter-eventlistener-plugin/src/main/java/com/twitter/presto/plugin/eventlistener/TwitterEventHandler.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.twitter.presto.plugin.eventlistener;
+
+import com.facebook.presto.spi.eventlistener.QueryCompletedEvent;
+import com.facebook.presto.spi.eventlistener.QueryCreatedEvent;
+import com.facebook.presto.spi.eventlistener.SplitCompletedEvent;
+
+public interface TwitterEventHandler
+{
+    default void handleQueryCreated(QueryCreatedEvent queryCreatedEvent)
+    {
+    }
+
+    default void handleQueryCompleted(QueryCompletedEvent queryCompletedEvent)
+    {
+    }
+
+    default void handleSplitCompleted(SplitCompletedEvent splitCompletedEvent)
+    {
+    }
+}

--- a/twitter-eventlistener-plugin/src/main/java/com/twitter/presto/plugin/eventlistener/TwitterEventListener.java
+++ b/twitter-eventlistener-plugin/src/main/java/com/twitter/presto/plugin/eventlistener/TwitterEventListener.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.twitter.presto.plugin.eventlistener;
+
+import com.facebook.presto.spi.eventlistener.EventListener;
+import com.facebook.presto.spi.eventlistener.QueryCompletedEvent;
+import com.facebook.presto.spi.eventlistener.QueryCreatedEvent;
+import com.facebook.presto.spi.eventlistener.SplitCompletedEvent;
+
+import javax.inject.Inject;
+
+import java.util.Set;
+
+import static java.util.Objects.requireNonNull;
+
+public class TwitterEventListener
+        implements EventListener
+{
+    private final Set<TwitterEventHandler> handlers;
+
+    @Inject
+    public TwitterEventListener(Set<TwitterEventHandler> handlers)
+    {
+        this.handlers = requireNonNull(handlers, "handlers is null");
+    }
+
+    @Override
+    public void queryCreated(QueryCreatedEvent queryCreatedEvent)
+    {
+        for (TwitterEventHandler handler : handlers) {
+            handler.handleQueryCreated(queryCreatedEvent);
+        }
+    }
+
+    @Override
+    public void queryCompleted(QueryCompletedEvent queryCompletedEvent)
+    {
+        for (TwitterEventHandler handler : handlers) {
+            handler.handleQueryCompleted(queryCompletedEvent);
+        }
+    }
+
+    @Override
+    public void splitCompleted(SplitCompletedEvent splitCompletedEvent)
+    {
+        for (TwitterEventHandler handler : handlers) {
+            handler.handleSplitCompleted(splitCompletedEvent);
+        }
+    }
+}

--- a/twitter-eventlistener-plugin/src/main/java/com/twitter/presto/plugin/eventlistener/TwitterEventListenerConfig.java
+++ b/twitter-eventlistener-plugin/src/main/java/com/twitter/presto/plugin/eventlistener/TwitterEventListenerConfig.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.twitter.presto.plugin.eventlistener;
+
+import io.airlift.configuration.Config;
+
+public class TwitterEventListenerConfig
+{
+    private String scribeCategory;
+
+    public String getScribeCategory()
+    {
+        return scribeCategory;
+    }
+
+    @Config("event-listener.scribe-category")
+    public TwitterEventListenerConfig setScribeCategory(String scribeCategory)
+    {
+        this.scribeCategory = scribeCategory;
+        return this;
+    }
+}

--- a/twitter-eventlistener-plugin/src/main/java/com/twitter/presto/plugin/eventlistener/TwitterEventListenerFactory.java
+++ b/twitter-eventlistener-plugin/src/main/java/com/twitter/presto/plugin/eventlistener/TwitterEventListenerFactory.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.twitter.presto.plugin.eventlistener;
+
+import com.facebook.presto.spi.eventlistener.EventListener;
+import com.facebook.presto.spi.eventlistener.EventListenerFactory;
+import com.google.inject.Injector;
+import io.airlift.bootstrap.Bootstrap;
+
+import java.util.Map;
+
+import static com.google.common.base.Throwables.throwIfUnchecked;
+
+public class TwitterEventListenerFactory
+        implements EventListenerFactory
+{
+    @Override
+    public String getName()
+    {
+        return "twitter-event-listener";
+    }
+
+    @Override
+    public EventListener create(Map<String, String> config)
+    {
+        try {
+            Bootstrap app = new Bootstrap(new TwitterEventListenerModule());
+
+            Injector injector = app
+                    .strictConfig()
+                    .doNotInitializeLogging()
+                    .setRequiredConfigurationProperties(config)
+                    .initialize();
+
+            return injector.getInstance(TwitterEventListener.class);
+        }
+        catch (InterruptedException ie) {
+            Thread.currentThread().interrupt();
+            throw new RuntimeException("Interrupted while creating connector", ie);
+        }
+        catch (Exception e) {
+            throwIfUnchecked(e);
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/twitter-eventlistener-plugin/src/main/java/com/twitter/presto/plugin/eventlistener/TwitterEventListenerModule.java
+++ b/twitter-eventlistener-plugin/src/main/java/com/twitter/presto/plugin/eventlistener/TwitterEventListenerModule.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.twitter.presto.plugin.eventlistener;
+
+import com.google.inject.Binder;
+import com.google.inject.Scopes;
+import com.google.inject.multibindings.Multibinder;
+import com.twitter.presto.plugin.eventlistener.scriber.QueryCompletedEventScriber;
+import io.airlift.configuration.AbstractConfigurationAwareModule;
+
+import static com.google.inject.multibindings.Multibinder.newSetBinder;
+import static io.airlift.configuration.ConfigBinder.configBinder;
+
+public class TwitterEventListenerModule
+        extends AbstractConfigurationAwareModule
+{
+    @Override
+    public void setup(Binder binder)
+    {
+        binder.bind(TwitterEventListener.class).in(Scopes.SINGLETON);
+        configBinder(binder).bindConfig(TwitterEventListenerConfig.class);
+        TwitterEventListenerConfig config = buildConfigObject(TwitterEventListenerConfig.class);
+        Multibinder<TwitterEventHandler> twitterEventHandlerBinder = newSetBinder(binder, TwitterEventHandler.class);
+        if (config.getScribeCategory() != null) {
+            twitterEventHandlerBinder.addBinding().to(QueryCompletedEventScriber.class).in(Scopes.SINGLETON);
+        }
+    }
+}

--- a/twitter-eventlistener-plugin/src/main/java/com/twitter/presto/plugin/eventlistener/TwitterEventListenerPlugin.java
+++ b/twitter-eventlistener-plugin/src/main/java/com/twitter/presto/plugin/eventlistener/TwitterEventListenerPlugin.java
@@ -1,0 +1,28 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.twitter.presto.plugin.eventlistener;
+
+import com.facebook.presto.spi.Plugin;
+import com.facebook.presto.spi.eventlistener.EventListenerFactory;
+import com.google.common.collect.ImmutableList;
+
+public class TwitterEventListenerPlugin
+        implements Plugin
+{
+    @Override
+    public Iterable<EventListenerFactory> getEventListenerFactories()
+    {
+        return ImmutableList.of(new TwitterEventListenerFactory());
+    }
+}

--- a/twitter-eventlistener-plugin/src/main/java/com/twitter/presto/plugin/eventlistener/scriber/QueryCompletedEventScriber.java
+++ b/twitter-eventlistener-plugin/src/main/java/com/twitter/presto/plugin/eventlistener/scriber/QueryCompletedEventScriber.java
@@ -1,0 +1,131 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.twitter.presto.plugin.eventlistener.scriber;
+
+import com.facebook.presto.spi.eventlistener.QueryCompletedEvent;
+import com.facebook.presto.spi.eventlistener.QueryContext;
+import com.facebook.presto.spi.eventlistener.QueryFailureInfo;
+import com.facebook.presto.spi.eventlistener.QueryMetadata;
+import com.facebook.presto.spi.eventlistener.QueryStatistics;
+import com.twitter.presto.plugin.eventlistener.TwitterEventHandler;
+import com.twitter.presto.plugin.eventlistener.TwitterEventListenerConfig;
+import com.twitter.presto.thriftjava.QueryCompletionEvent;
+import com.twitter.presto.thriftjava.QueryState;
+import io.airlift.log.Logger;
+import org.apache.thrift.TException;
+
+import javax.inject.Inject;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Class that scribes query completion events
+ */
+public class QueryCompletedEventScriber
+        implements TwitterEventHandler
+{
+    private static final String DASH = "-";
+    private static final Logger log = Logger.get(QueryCompletedEventScriber.class);
+
+    private final TwitterScriber scriber;
+
+    @Inject
+    public QueryCompletedEventScriber(TwitterEventListenerConfig config)
+    {
+        requireNonNull(config.getScribeCategory(), "scribe category is null");
+        this.scriber = new TwitterScriber(config.getScribeCategory());
+    }
+
+    public QueryCompletedEventScriber(TwitterScriber scriber)
+    {
+        this.scriber = requireNonNull(scriber, "scriber is null");
+    }
+
+    @Override
+    public void handleQueryCompleted(QueryCompletedEvent event)
+    {
+        try {
+            scriber.scribe(toThriftQueryCompletionEvent(event));
+        }
+        catch (TException e) {
+            log.warn(e,
+                    String.format("Could not serialize thrift object of Query(id=%s, user=%s, env=%s, schema=%s.%s)",
+                            event.getMetadata().getQueryId(),
+                            event.getContext().getUser(),
+                            event.getContext().getEnvironment(),
+                            event.getContext().getCatalog().orElse(DASH),
+                            event.getContext().getSchema().orElse(DASH)));
+        }
+    }
+
+    private static QueryCompletionEvent toThriftQueryCompletionEvent(QueryCompletedEvent event)
+    {
+        QueryMetadata eventMetadata = event.getMetadata();
+        QueryContext eventContext = event.getContext();
+        QueryStatistics eventStat = event.getStatistics();
+
+        QueryCompletionEvent thriftEvent =
+                new com.twitter.presto.thriftjava.QueryCompletionEvent();
+
+        thriftEvent.setQuery_id(eventMetadata.getQueryId());
+        thriftEvent.setTransaction_id(eventMetadata.getTransactionId().orElse(DASH));
+        thriftEvent.setUser(eventContext.getUser());
+        thriftEvent.setPrincipal(eventContext.getPrincipal().orElse(DASH));
+        thriftEvent.setSource(eventContext.getSource().orElse(DASH));
+        thriftEvent.setServer_version(eventContext.getServerVersion());
+        thriftEvent.setEnvironment(eventContext.getEnvironment());
+        thriftEvent.setCatalog(eventContext.getCatalog().orElse(DASH));
+        thriftEvent.setSchema(eventContext.getSchema().orElse(DASH));
+        Map<String, List<String>> queriedColumnsByTable = new HashMap<>();
+        event.getIoMetadata().getInputs().forEach(input -> queriedColumnsByTable.put(String.format("%s.%s", input.getSchema(), input.getTable()), input.getColumns()));
+        thriftEvent.setQueried_columns_by_table(queriedColumnsByTable);
+        thriftEvent.setRemote_client_address(eventContext.getRemoteClientAddress().orElse(DASH));
+        thriftEvent.setUser_agent(eventContext.getUserAgent().orElse(DASH));
+        thriftEvent.setQuery_state(QueryState.valueOf(eventMetadata.getQueryState()));
+        thriftEvent.setUri(eventMetadata.getUri().toString());
+        thriftEvent.setQuery(eventMetadata.getQuery());
+        thriftEvent.setCreate_time_ms(event.getCreateTime().toEpochMilli());
+        thriftEvent.setExecution_start_time_ms(event.getExecutionStartTime().toEpochMilli());
+        thriftEvent.setEnd_time_ms(event.getEndTime().toEpochMilli());
+        thriftEvent.setQueued_time_ms(eventStat.getQueuedTime().toMillis());
+        thriftEvent.setQuery_wall_time_ms(eventStat.getWallTime().toMillis());
+        thriftEvent.setCumulative_memory_bytesecond(eventStat.getCumulativeMemory());
+        thriftEvent.setPeak_memory_bytes(eventStat.getPeakTotalNonRevocableMemoryBytes());
+        thriftEvent.setCpu_time_ms(eventStat.getCpuTime().toMillis());
+        if (eventStat.getAnalysisTime().isPresent()) {
+            thriftEvent.setAnalysis_time_ms(eventStat.getAnalysisTime().get().toMillis());
+        }
+        thriftEvent.setTotal_bytes(eventStat.getTotalBytes());
+        thriftEvent.setQuery_stages(QueryStatsHelper.getQueryStages(eventMetadata));
+        thriftEvent.setOperator_summaries(QueryStatsHelper.getOperatorSummaries(eventStat));
+        thriftEvent.setTotal_rows(eventStat.getTotalRows());
+        thriftEvent.setSplits(eventStat.getCompletedSplits());
+        if (event.getFailureInfo().isPresent()) {
+            QueryFailureInfo eventFailureInfo = event.getFailureInfo().get();
+            thriftEvent.setError_code_id(eventFailureInfo.getErrorCode().getCode());
+            thriftEvent.setError_code_name(eventFailureInfo.getErrorCode().getName());
+            thriftEvent.setFailure_type(eventFailureInfo.getFailureType().orElse(DASH));
+            thriftEvent.setFailure_message(eventFailureInfo.getFailureMessage().orElse(DASH));
+            thriftEvent.setFailure_task(eventFailureInfo.getFailureTask().orElse(DASH));
+            thriftEvent.setFailure_host(eventFailureInfo.getFailureHost().orElse(DASH));
+            thriftEvent.setFailures_json(eventFailureInfo.getFailuresJson());
+        }
+
+        return thriftEvent;
+    }
+}

--- a/twitter-eventlistener-plugin/src/main/java/com/twitter/presto/plugin/eventlistener/scriber/QueryStatsHelper.java
+++ b/twitter-eventlistener-plugin/src/main/java/com/twitter/presto/plugin/eventlistener/scriber/QueryStatsHelper.java
@@ -1,0 +1,213 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.twitter.presto.plugin.eventlistener.scriber;
+
+import com.facebook.presto.spi.eventlistener.QueryMetadata;
+import com.facebook.presto.spi.eventlistener.QueryStatistics;
+import com.twitter.presto.thriftjava.OperatorStats;
+import com.twitter.presto.thriftjava.QueryStageInfo;
+import io.airlift.log.Logger;
+import io.airlift.units.DataSize;
+import io.airlift.units.Duration;
+
+import javax.json.Json;
+import javax.json.JsonObject;
+import javax.json.JsonReader;
+import javax.json.JsonValue.ValueType;
+
+import java.io.StringReader;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Queue;
+import java.util.stream.Collectors;
+
+public class QueryStatsHelper
+{
+    private static final Logger log = Logger.get(QueryStatsHelper.class);
+
+    private QueryStatsHelper()
+    {
+        throw new AssertionError();
+    }
+
+    private static long getBytesOrNegativeOne(String strVal)
+    {
+        try {
+            return DataSize.valueOf(strVal).toBytes();
+        }
+        catch (IllegalArgumentException e) {
+            log.warn(e,
+                    String.format("Failed to parse io.airlift.units.DataSize '%s', returning -1", strVal));
+            return -1;
+        }
+    }
+
+    private static long getMillisOrNegativeOne(String strVal)
+    {
+        try {
+            return Duration.valueOf(strVal).toMillis();
+        }
+        catch (IllegalArgumentException e) {
+            log.warn(e,
+                    String.format("Failed to parse io.airlift.units.Duration '%s', returning -1", strVal));
+            return -1;
+        }
+    }
+
+    private static QueryStageInfo getQueryStageInfo(int stageId, JsonObject stage)
+    {
+        QueryStageInfo stageInfo = new QueryStageInfo();
+
+        stageInfo.stage_id = stageId;
+        try {
+            JsonObject stageStats = stage.getJsonObject("latestAttemptExecutionInfo").getJsonObject("stats");
+            stageInfo.raw_input_data_size_bytes = getBytesOrNegativeOne(stageStats.getString("rawInputDataSize"));
+            stageInfo.output_data_size_bytes = getBytesOrNegativeOne(stageStats.getString("outputDataSize"));
+            stageInfo.completed_tasks = stageStats.getInt("completedTasks");
+            stageInfo.completed_drivers = stageStats.getInt("completedDrivers");
+            stageInfo.cumulative_memory = stageStats.getJsonNumber("cumulativeUserMemory").doubleValue();
+            stageInfo.peak_memory_reservation_bytes = getBytesOrNegativeOne(stageStats.getString("peakUserMemoryReservation"));
+            stageInfo.total_scheduled_time_millis = getMillisOrNegativeOne(stageStats.getString("totalScheduledTime"));
+            stageInfo.total_cpu_time_millis = getMillisOrNegativeOne(stageStats.getString("totalCpuTime"));
+            stageInfo.total_blocked_time_millis = getMillisOrNegativeOne(stageStats.getString("totalBlockedTime"));
+        }
+        catch (Exception e) {
+            log.error(e, String.format("Error retrieving stage stats for stage %d", stageId));
+            return null;
+        }
+
+        return stageInfo;
+    }
+
+    private static OperatorStats getOperatorStat(String operatorSummaryStr)
+    {
+        try {
+            JsonReader jsonReader = Json.createReader(new StringReader(operatorSummaryStr));
+            return getOperatorStat(jsonReader.readObject());
+        }
+        catch (Exception e) {
+            log.error(e, String.format("Error retrieving operator stats from string:\n%s\n", operatorSummaryStr));
+        }
+
+        return null;
+    }
+
+    private static OperatorStats getOperatorStat(JsonObject obj)
+    {
+        OperatorStats operatorStats = new OperatorStats();
+
+        try {
+            operatorStats.pipeline_id = obj.getInt("pipelineId");
+            operatorStats.operator_id = obj.getInt("operatorId");
+            operatorStats.plan_node_id = obj.getString("planNodeId");
+            operatorStats.operator_type = obj.getString("operatorType");
+            operatorStats.total_drivers = obj.getJsonNumber("totalDrivers").longValue();
+            operatorStats.add_input_calls = obj.getJsonNumber("addInputCalls").longValue();
+            operatorStats.add_input_wall_millis = getMillisOrNegativeOne(obj.getString("addInputWall"));
+            operatorStats.add_input_cpu_millis = getMillisOrNegativeOne(obj.getString("addInputCpu"));
+            operatorStats.input_data_size_bytes = getBytesOrNegativeOne(obj.getString("inputDataSize"));
+            operatorStats.input_positions = obj.getJsonNumber("inputPositions").longValue();
+            operatorStats.sum_squared_input_positions = obj.getJsonNumber("sumSquaredInputPositions").doubleValue();
+            operatorStats.get_output_calls = obj.getJsonNumber("getOutputCalls").longValue();
+            operatorStats.get_output_wall_millis = getMillisOrNegativeOne(obj.getString("getOutputWall"));
+            operatorStats.get_output_cpu_millis = getMillisOrNegativeOne(obj.getString("getOutputCpu"));
+            operatorStats.output_data_size_bytes = getBytesOrNegativeOne(obj.getString("outputDataSize"));
+            operatorStats.output_positions = obj.getJsonNumber("outputPositions").longValue();
+            operatorStats.blocked_wall_millis = getMillisOrNegativeOne(obj.getString("blockedWall"));
+            operatorStats.finish_calls = obj.getJsonNumber("finishCalls").longValue();
+            operatorStats.finish_wall_millis = getMillisOrNegativeOne(obj.getString("finishWall"));
+            operatorStats.finish_cpu_millis = getMillisOrNegativeOne(obj.getString("finishCpu"));
+            operatorStats.memory_reservation_bytes = getBytesOrNegativeOne(obj.getString("userMemoryReservation"));
+            operatorStats.system_memory_reservation_bytes = getBytesOrNegativeOne(obj.getString("systemMemoryReservation"));
+        }
+        catch (Exception e) {
+            log.error(e, String.format("Error retrieving operator stats from JsonObject:\n%s\n", obj.toString()));
+            return null;
+        }
+
+        return operatorStats;
+    }
+
+    public static Map<Integer, QueryStageInfo> getQueryStages(QueryMetadata eventMetadata)
+    {
+        if (!eventMetadata.getPayload().isPresent()) {
+            return null;
+        }
+
+        String payload = eventMetadata.getPayload().get();
+        Queue<JsonObject> stageJsonObjs = new LinkedList<>();
+        try {
+            JsonReader jsonReader = Json.createReader(new StringReader(payload));
+            stageJsonObjs.add(jsonReader.readObject());
+        }
+        catch (Exception e) {
+            log.error(e,
+                    String.format("getQueryStages - Unable to extract JsonObject out of following blob:\n%s\n", payload));
+            return null;
+        }
+
+        Map<Integer, QueryStageInfo> stages = new HashMap<>();
+        while (!stageJsonObjs.isEmpty()) {
+            JsonObject cur = stageJsonObjs.poll();
+            String stageIdStr;
+            try {
+                stageIdStr = cur.getString("stageId");
+                int stageId = Integer.parseInt(stageIdStr.split("\\.")[1]);
+                QueryStageInfo curStage = getQueryStageInfo(stageId, cur);
+                if (curStage != null) {
+                    stages.put(stageId, getQueryStageInfo(stageId, cur));
+                }
+            }
+            catch (Exception e) {
+                log.error(e,
+                        String.format("Failed to parse QueryStageInfo from JsonObject:\n%s\n", cur.toString()));
+                return null;
+            }
+
+            try {
+                cur.getJsonArray("subStages")
+                        .stream()
+                        .filter(val -> val.getValueType() == ValueType.OBJECT)
+                        .forEach(val -> stageJsonObjs.add((JsonObject) val));
+            }
+            catch (Exception e) {
+                log.error(e,
+                        String.format("Failed to get subStages for stage %s, treating as no subStages", stageIdStr));
+            }
+        }
+
+        return stages;
+    }
+
+    public static List<OperatorStats> getOperatorSummaries(QueryStatistics eventStat)
+    {
+        try {
+            return eventStat.getOperatorSummaries()
+                    .stream()
+                    .filter(val -> val != null && !val.isEmpty())
+                    .map(QueryStatsHelper::getOperatorStat)
+                    .filter(Objects::nonNull)
+                    .collect(Collectors.toList());
+        }
+        catch (Exception e) {
+            log.error(e,
+                    String.format("Error converting List<String> to List<OperatorStats>:\n%s\n", eventStat.getOperatorSummaries().toString()));
+        }
+
+        return null;
+    }
+}

--- a/twitter-eventlistener-plugin/src/main/java/com/twitter/presto/plugin/eventlistener/scriber/TwitterScriber.java
+++ b/twitter-eventlistener-plugin/src/main/java/com/twitter/presto/plugin/eventlistener/scriber/TwitterScriber.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.twitter.presto.plugin.eventlistener.scriber;
+
+import com.twitter.logging.BareFormatter$;
+import com.twitter.logging.Level;
+import com.twitter.logging.QueueingHandler;
+import com.twitter.logging.ScribeHandler;
+import org.apache.thrift.TBase;
+import org.apache.thrift.TException;
+import org.apache.thrift.TSerializer;
+
+import java.util.Base64;
+import java.util.logging.LogRecord;
+
+public class TwitterScriber
+{
+    private static final int MAX_QUEUE_SIZE = 1000;
+
+    private QueueingHandler queueingHandler;
+
+    // TSerializer is not thread safe
+    private final ThreadLocal<TSerializer> serializer = ThreadLocal.withInitial(() -> new TSerializer());
+
+    public TwitterScriber(String scribeCategory)
+    {
+        ScribeHandler scribeHandler = new ScribeHandler(
+                ScribeHandler.DefaultHostname(),
+                ScribeHandler.DefaultPort(),
+                scribeCategory,
+                ScribeHandler.DefaultBufferTime(),
+                ScribeHandler.DefaultConnectBackoff(),
+                ScribeHandler.DefaultMaxMessagesPerTransaction(),
+                ScribeHandler.DefaultMaxMessagesToBuffer(),
+                BareFormatter$.MODULE$,
+                scala.Option.apply(null));
+        queueingHandler = new QueueingHandler(scribeHandler, MAX_QUEUE_SIZE);
+    }
+
+    public void scribe(TBase thriftMessage)
+            throws TException
+    {
+        scribe(serializeThriftToString(thriftMessage));
+    }
+
+    /**
+     * Serialize a thrift object to bytes, compress, then encode as a base64 string.
+     * Throws TException
+     */
+    private String serializeThriftToString(TBase thriftMessage)
+            throws TException
+    {
+        return Base64.getEncoder().encodeToString(serializer.get().serialize(thriftMessage));
+    }
+
+    protected void scribe(String message)
+    {
+        LogRecord logRecord = new LogRecord(Level.ALL, message);
+        queueingHandler.publish(logRecord);
+    }
+}

--- a/twitter-eventlistener-plugin/src/main/thrift/presto.thrift
+++ b/twitter-eventlistener-plugin/src/main/thrift/presto.thrift
@@ -1,0 +1,111 @@
+namespace java com.twitter.presto.thriftjava
+#@namespace scala com.twitter.presto.thriftscala
+
+enum QueryState {
+    QUEUED    = 1,
+    PLANNING  = 2,
+    STARTING  = 3,
+    RUNNING   = 4,
+    FINISHING = 5,
+    FINISHED  = 6,
+    FAILED    = 7
+}
+
+struct OperatorStats {
+    1: required i32 pipeline_id
+    2: required i32 operator_id
+    3: required string plan_node_id
+    4: required string operator_type
+    5: required i64 total_drivers
+    6: required i64 add_input_calls
+    7: required i64 add_input_wall_millis
+    8: required i64 add_input_cpu_millis
+    9: required i64 add_input_user_millis
+    10: required i64 input_data_size_bytes
+    11: required i64 input_positions
+    12: required double sum_squared_input_positions
+    13: required i64 get_output_calls
+    14: required i64 get_output_wall_millis
+    15: required i64 get_output_cpu_millis
+    16: required i64 get_output_user_millis
+    17: required i64 output_data_size_bytes
+    18: required i64 output_positions
+    19: required i64 blocked_wall_millis
+    20: required i64 finish_calls
+    21: required i64 finish_wall_millis
+    22: required i64 finish_cpu_millis
+    23: required i64 finish_user_millis
+    24: required i64 memory_reservation_bytes
+    25: required i64 system_memory_reservation_bytes
+}(persisted='true')
+
+struct QueryStageInfo {
+    1: required i32 stage_id
+    2: required i64 raw_input_data_size_bytes
+    3: required i64 output_data_size_bytes
+    4: required i32 completed_tasks
+    5: required i32 completed_drivers
+    6: required double cumulative_memory
+    7: required i64 peak_memory_reservation_bytes
+    8: required i64 total_scheduled_time_millis
+    9: required i64 total_cpu_time_millis
+    10: required i64 total_user_time_millis
+    11: required i64 total_blocked_time_millis
+}(persisted='true')
+
+/**
+ * Thrift version of a Presto QueryCompletionEvent. See QueryCompletionEvent for usage.
+ */
+struct QueryCompletionEvent {
+    1: required string query_id
+    2: optional string transaction_id
+    3: required string user
+    4: optional string principal
+    5: optional string source
+    6: optional string server_version
+    7: optional string environment
+    8: optional string catalog
+    9: optional string schema
+    10: optional string remote_client_address
+    11: optional string user_agent
+    12: required QueryState query_state
+    13: optional string uri
+    14: optional list<string> field_names
+    15: required string query
+    16: required i64 create_time_ms
+    17: required i64 execution_start_time_ms
+    18: required i64 end_time_ms
+    19: required i64 queued_time_ms
+    20: optional i64 analysis_time_ms
+    21: required i64 distributed_planning_time_ms
+    22: required i64 total_split_wall_time_ms
+    23: required i64 total_split_cpu_time_ms
+    24: required i64 total_bytes
+    25: required i64 total_rows
+    26: required i32 splits
+    27: optional i32 error_code_id
+    28: optional string error_code_name
+    29: optional string failure_type
+    30: optional string failure_message
+    31: optional string failure_task
+    32: optional string failure_host
+    33: optional string output_stage_json
+    34: optional string failures_json
+    35: optional string inputs_json
+    36: optional string session_properties_json
+
+    # precalcuate some derived data to simplify queries
+    200: required i64 query_wall_time_ms
+    201: required i64 bytes_per_sec
+    202: required i64 bytes_per_cpu_sec
+    203: required i64 rows_per_sec
+    204: required i64 rows_per_cpu_sec
+
+    205: optional map<string, list<string>> queried_columns_by_table
+    206: optional map<i32, QueryStageInfo> query_stages
+    207: optional list<OperatorStats> operator_summaries
+
+    208: optional i64 peak_memory_bytes
+    209: optional double cumulative_memory_bytesecond
+    210: optional i64 cpu_time_ms
+}(persisted='true')

--- a/twitter-eventlistener-plugin/src/test/java/com/twitter/presto/plugin/eventlistener/TestTwitterEventListener.java
+++ b/twitter-eventlistener-plugin/src/test/java/com/twitter/presto/plugin/eventlistener/TestTwitterEventListener.java
@@ -1,0 +1,175 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.twitter.presto.plugin.eventlistener;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.spi.eventlistener.QueryCompletedEvent;
+import com.facebook.presto.spi.eventlistener.QueryCreatedEvent;
+import com.facebook.presto.spi.eventlistener.SplitCompletedEvent;
+import com.facebook.presto.testing.MaterializedResult;
+import com.facebook.presto.tests.DistributedQueryRunner;
+import com.facebook.presto.tpch.TpchPlugin;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import static com.facebook.presto.testing.TestingSession.testSessionBuilder;
+import static com.google.common.collect.Iterables.getOnlyElement;
+import static org.testng.Assert.assertEquals;
+
+@Test(singleThreaded = true)
+public class TestTwitterEventListener
+{
+    private static final int SPLITS_PER_NODE = 3;
+    private final TestingTwitterEventHandler handler = new TestingTwitterEventHandler();
+
+    private DistributedQueryRunner queryRunner;
+    private Session session;
+
+    @BeforeClass
+    private void setUp()
+            throws Exception
+    {
+        session = testSessionBuilder()
+                .setSystemProperty("task_concurrency", "1")
+                .setCatalog("tpch")
+                .setSchema("tiny")
+                .setClientInfo("{\"clientVersion\":\"testVersion\"}")
+                .build();
+        queryRunner = new DistributedQueryRunner(session, 1);
+        queryRunner.installPlugin(new TpchPlugin());
+        queryRunner.installPlugin(new TestingTwitterEventListenerPlugin(handler));
+        queryRunner.createCatalog("tpch", "tpch", ImmutableMap.of("tpch.splits-per-node", Integer.toString(SPLITS_PER_NODE)));
+    }
+
+    @AfterClass(alwaysRun = true)
+    private void tearDown()
+    {
+        queryRunner.close();
+        queryRunner = null;
+    }
+
+    @Test
+    public void testConstantQuery()
+            throws Exception
+    {
+        // QueryCreated: 1, QueryCompleted: 1, Splits: 1
+        runQueryAndWaitForEvents("SELECT 1", 3);
+
+        QueryCreatedEvent queryCreatedEvent = getOnlyElement(handler.getQueryCreatedEvents());
+        assertEquals(queryCreatedEvent.getContext().getServerVersion(), "testversion");
+        assertEquals(queryCreatedEvent.getContext().getServerAddress(), "127.0.0.1");
+        assertEquals(queryCreatedEvent.getContext().getEnvironment(), "testing");
+        assertEquals(queryCreatedEvent.getContext().getClientInfo().get(), "{\"clientVersion\":\"testVersion\"}");
+        assertEquals(queryCreatedEvent.getMetadata().getQuery(), "SELECT 1");
+
+        QueryCompletedEvent queryCompletedEvent = getOnlyElement(handler.getQueryCompletedEvents());
+        assertEquals(queryCompletedEvent.getStatistics().getTotalRows(), 0L);
+        assertEquals(queryCompletedEvent.getContext().getClientInfo().get(), "{\"clientVersion\":\"testVersion\"}");
+        assertEquals(queryCreatedEvent.getMetadata().getQueryId(), queryCompletedEvent.getMetadata().getQueryId());
+
+        List<SplitCompletedEvent> splitCompletedEvents = handler.getSplitCompletedEvents();
+        assertEquals(splitCompletedEvents.get(0).getQueryId(), queryCompletedEvent.getMetadata().getQueryId());
+        assertEquals(splitCompletedEvents.get(0).getStatistics().getCompletedPositions(), 1);
+    }
+
+    private MaterializedResult runQueryAndWaitForEvents(String sql, int numEventsExpected)
+            throws Exception
+    {
+        handler.initialize(numEventsExpected);
+        MaterializedResult result = queryRunner.execute(session, sql);
+        handler.waitForEvents(10);
+
+        return result;
+    }
+
+    static class TestingTwitterEventHandler
+            implements TwitterEventHandler
+    {
+        private ImmutableList.Builder<QueryCreatedEvent> queryCreatedEvents;
+        private ImmutableList.Builder<QueryCompletedEvent> queryCompletedEvents;
+        private ImmutableList.Builder<SplitCompletedEvent> splitCompletedEvents;
+
+        private CountDownLatch eventsLatch;
+
+        public synchronized void initialize(int numEvents)
+        {
+            queryCreatedEvents = ImmutableList.builder();
+            queryCompletedEvents = ImmutableList.builder();
+            splitCompletedEvents = ImmutableList.builder();
+
+            eventsLatch = new CountDownLatch(numEvents);
+        }
+
+        public void waitForEvents(int timeoutSeconds)
+                throws InterruptedException
+        {
+            eventsLatch.await(timeoutSeconds, TimeUnit.SECONDS);
+        }
+
+        public synchronized void addQueryCreated(QueryCreatedEvent event)
+        {
+            queryCreatedEvents.add(event);
+            eventsLatch.countDown();
+        }
+
+        public synchronized void addQueryCompleted(QueryCompletedEvent event)
+        {
+            queryCompletedEvents.add(event);
+            eventsLatch.countDown();
+        }
+
+        public synchronized void addSplitCompleted(SplitCompletedEvent event)
+        {
+            splitCompletedEvents.add(event);
+            eventsLatch.countDown();
+        }
+
+        public List<QueryCreatedEvent> getQueryCreatedEvents()
+        {
+            return queryCreatedEvents.build();
+        }
+
+        public List<QueryCompletedEvent> getQueryCompletedEvents()
+        {
+            return queryCompletedEvents.build();
+        }
+
+        public List<SplitCompletedEvent> getSplitCompletedEvents()
+        {
+            return splitCompletedEvents.build();
+        }
+
+        public void handleQueryCreated(QueryCreatedEvent queryCreatedEvent)
+        {
+            addQueryCreated(queryCreatedEvent);
+        }
+
+        public void handleQueryCompleted(QueryCompletedEvent queryCompletedEvent)
+        {
+            addQueryCompleted(queryCompletedEvent);
+        }
+
+        public void handleSplitCompleted(SplitCompletedEvent splitCompletedEvent)
+        {
+            addSplitCompleted(splitCompletedEvent);
+        }
+    }
+}

--- a/twitter-eventlistener-plugin/src/test/java/com/twitter/presto/plugin/eventlistener/TestTwitterEventListenerConfig.java
+++ b/twitter-eventlistener-plugin/src/test/java/com/twitter/presto/plugin/eventlistener/TestTwitterEventListenerConfig.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.twitter.presto.plugin.eventlistener;
+
+import com.google.common.collect.ImmutableMap;
+import io.airlift.configuration.testing.ConfigAssertions;
+import org.testng.annotations.Test;
+
+import java.util.Map;
+
+public class TestTwitterEventListenerConfig
+{
+    @Test
+    public void testDefaults()
+    {
+        ConfigAssertions.assertRecordedDefaults(ConfigAssertions.recordDefaults(TwitterEventListenerConfig.class).setScribeCategory(null));
+    }
+
+    @Test
+    public void testExplicitPropertyMappings()
+    {
+        Map<String, String> properties = new ImmutableMap.Builder<String, String>()
+                .put("event-listener.scribe-category", "test")
+                .build();
+
+        TwitterEventListenerConfig expected = new TwitterEventListenerConfig()
+                .setScribeCategory("test");
+
+        ConfigAssertions.assertFullMapping(properties, expected);
+    }
+}

--- a/twitter-eventlistener-plugin/src/test/java/com/twitter/presto/plugin/eventlistener/TestTwitterEventListenerPlugin.java
+++ b/twitter-eventlistener-plugin/src/test/java/com/twitter/presto/plugin/eventlistener/TestTwitterEventListenerPlugin.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.twitter.presto.plugin.eventlistener;
+
+import com.facebook.presto.spi.Plugin;
+import com.facebook.presto.spi.eventlistener.EventListener;
+import com.facebook.presto.spi.eventlistener.EventListenerFactory;
+import com.google.common.collect.ImmutableMap;
+import org.testng.annotations.Test;
+
+import java.util.Map;
+import java.util.ServiceLoader;
+
+import static com.google.common.collect.Iterables.getOnlyElement;
+import static io.airlift.testing.Assertions.assertInstanceOf;
+import static org.testng.Assert.assertNotNull;
+
+public class TestTwitterEventListenerPlugin
+{
+    @Test
+    public void testPlugin()
+    {
+        TwitterEventListenerPlugin plugin = loadPlugin(TwitterEventListenerPlugin.class);
+
+        EventListenerFactory factory = getOnlyElement(plugin.getEventListenerFactories());
+        assertInstanceOf(factory, TwitterEventListenerFactory.class);
+
+        Map<String, String> config = ImmutableMap.of();
+
+        EventListener eventListener = factory.create(config);
+        assertNotNull(eventListener);
+        assertInstanceOf(eventListener, TwitterEventListener.class);
+    }
+
+    @SuppressWarnings("unchecked")
+    private static <T extends Plugin> T loadPlugin(Class<T> clazz)
+    {
+        for (Plugin plugin : ServiceLoader.load(Plugin.class)) {
+            if (clazz.isInstance(plugin)) {
+                return (T) plugin;
+            }
+        }
+        throw new AssertionError("did not find plugin: " + clazz.getName());
+    }
+}

--- a/twitter-eventlistener-plugin/src/test/java/com/twitter/presto/plugin/eventlistener/TestingTwitterEventListenerPlugin.java
+++ b/twitter-eventlistener-plugin/src/test/java/com/twitter/presto/plugin/eventlistener/TestingTwitterEventListenerPlugin.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.twitter.presto.plugin.eventlistener;
+
+import com.facebook.presto.spi.Plugin;
+import com.facebook.presto.spi.eventlistener.EventListener;
+import com.facebook.presto.spi.eventlistener.EventListenerFactory;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+
+import java.util.Map;
+
+import static java.lang.String.format;
+import static java.util.Objects.requireNonNull;
+
+public class TestingTwitterEventListenerPlugin
+        implements Plugin
+{
+    private EventListenerFactory factory;
+
+    public TestingTwitterEventListenerPlugin(TwitterEventHandler... handlers)
+    {
+        this.factory = new TestingTwitterEventListenerFactory(requireNonNull(handlers, "handler is null"));
+    }
+
+    @Override
+    public Iterable<EventListenerFactory> getEventListenerFactories()
+    {
+        return ImmutableList.of(factory);
+    }
+
+    private class TestingTwitterEventListenerFactory
+            implements EventListenerFactory
+    {
+        private TwitterEventHandler[] handlers;
+
+        public TestingTwitterEventListenerFactory(TwitterEventHandler... handlers)
+        {
+            for (TwitterEventHandler handler : handlers) {
+                requireNonNull(handler, format("handler is null"));
+            }
+            this.handlers = handlers;
+        }
+
+        @Override
+        public String getName()
+        {
+            return "testing-twitter-event-listener";
+        }
+
+        @Override
+        public EventListener create(Map<String, String> config)
+        {
+            return new TwitterEventListener(ImmutableSet.copyOf(handlers));
+        }
+    }
+}

--- a/twitter-eventlistener-plugin/src/test/java/com/twitter/presto/plugin/eventlistener/scriber/TestQueryCompletedEventScriber.java
+++ b/twitter-eventlistener-plugin/src/test/java/com/twitter/presto/plugin/eventlistener/scriber/TestQueryCompletedEventScriber.java
@@ -1,0 +1,209 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.twitter.presto.plugin.eventlistener.scriber;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.spi.security.Identity;
+import com.facebook.presto.testing.MaterializedResult;
+import com.facebook.presto.tests.DistributedQueryRunner;
+import com.facebook.presto.tpch.TpchPlugin;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.twitter.presto.plugin.eventlistener.TestingTwitterEventListenerPlugin;
+import com.twitter.presto.plugin.eventlistener.TwitterEventHandler;
+import com.twitter.presto.thriftjava.QueryCompletionEvent;
+import com.twitter.presto.thriftjava.QueryStageInfo;
+import com.twitter.presto.thriftjava.QueryState;
+import org.apache.thrift.TDeserializer;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import static com.facebook.presto.testing.TestingSession.testSessionBuilder;
+import static com.google.common.collect.Iterables.getOnlyElement;
+import static org.testng.Assert.assertEquals;
+
+@Test(singleThreaded = true)
+public class TestQueryCompletedEventScriber
+{
+    private static final TDeserializer tDeserializer = new TDeserializer();
+    // Currently, there is no way to pass principal from test client.
+    private static final Identity identity = new Identity("test_user", Optional.empty());
+    private final TestingTwitterScriber scriber = new TestingTwitterScriber();
+    private final TwitterEventHandler handler = new QueryCompletedEventScriber(scriber);
+
+    private DistributedQueryRunner queryRunner;
+    private Session session;
+
+    @BeforeClass
+    private void setUp()
+            throws Exception
+    {
+        session = testSessionBuilder()
+                .setSystemProperty("task_concurrency", "1")
+                .setCatalog("tpch")
+                .setSchema("tiny")
+                .setClientInfo("{\"clientVersion\":\"testVersion\"}")
+                .build();
+        queryRunner = new DistributedQueryRunner(session, 1);
+        queryRunner.installPlugin(new TpchPlugin());
+        queryRunner.installPlugin(new TestingTwitterEventListenerPlugin(handler));
+        queryRunner.createCatalog("tpch", "tpch");
+    }
+
+    @AfterClass(alwaysRun = true)
+    private void tearDown()
+    {
+        queryRunner.close();
+        queryRunner = null;
+    }
+
+    @Test
+    public void testConstantQuery()
+            throws Exception
+    {
+        Session session = testSessionBuilder()
+                .setCatalog("tpch")
+                .setSchema("tiny")
+                .setIdentity(identity)
+                .build();
+        runQueryAndWaitForEvents(session, "SELECT 1", 1);
+
+        String queryCompletedEvent = getOnlyElement(scriber.getMessages());
+        QueryCompletionEvent tEvent = new QueryCompletionEvent();
+        tDeserializer.deserialize(tEvent, Base64.getDecoder().decode(queryCompletedEvent));
+
+        // check user audit information
+        assertEquals(tEvent.getUser(), identity.getUser());
+
+        // check server audit information
+        assertEquals(tEvent.getSource(), "test");
+        assertEquals(tEvent.getServer_version(), "testversion");
+        assertEquals(tEvent.getEnvironment(), "testing");
+
+        // check query audit information
+        assertEquals(tEvent.getCatalog(), "tpch");
+        assertEquals(tEvent.getSchema(), "tiny");
+        assertEquals(tEvent.getQuery(), "SELECT 1");
+        assertEquals(tEvent.getQuery_state(), QueryState.FINISHED);
+
+        // check query stats information
+        assertEquals(tEvent.getTotal_rows(), 0L);
+        assertEquals(tEvent.getTotal_bytes(), 0L);
+    }
+
+    @Test
+    public void testNormalQuery()
+            throws Exception
+    {
+        runQueryAndWaitForEvents(session, "SELECT sum(linenumber) FROM lineitem", 1);
+
+        String queryCompletedEvent = getOnlyElement(scriber.getMessages());
+        QueryCompletionEvent tEvent = new QueryCompletionEvent();
+        tDeserializer.deserialize(tEvent, Base64.getDecoder().decode(queryCompletedEvent));
+
+        // check query audit information
+        assertEquals(tEvent.getQueried_columns_by_table(), ImmutableMap.of("sf0.01.lineitem", ImmutableList.of("linenumber")));
+        assertEquals(tEvent.getQuery_state(), QueryState.FINISHED);
+
+        // check query state information
+        assertEquals(tEvent.getTotal_rows(), 60175L);
+        assertEquals(tEvent.getTotal_bytes(), 0L);
+        assertEquals(tEvent.getSplits(), tEvent.getQuery_stages().values().stream()
+                .map(QueryStageInfo::getCompleted_drivers)
+                .reduce(0, Integer::sum).intValue());
+        assertEquals(tEvent.getCpu_time_ms(), tEvent.getQuery_stages().values().stream()
+                .map(QueryStageInfo::getTotal_cpu_time_millis)
+                .reduce(0L, Long::sum).longValue());
+    }
+
+    @Test
+    public void testFailedQuery()
+            throws Exception
+    {
+        String failureMessage;
+        // Run a query with Syntax Error
+        try {
+            runQueryAndWaitForEvents(session, "SELECT notexistcolumn FROM lineitem", 1);
+            failureMessage = "";
+        }
+        catch (Exception e) {
+            failureMessage = e.getMessage();
+        }
+
+        String queryCompletedEvent = getOnlyElement(scriber.getMessages());
+        QueryCompletionEvent tEvent = new QueryCompletionEvent();
+        tDeserializer.deserialize(tEvent, Base64.getDecoder().decode(queryCompletedEvent));
+
+        // check query failure information
+        assertEquals(tEvent.getQuery_state(), QueryState.FAILED);
+        assertEquals(tEvent.getError_code_id(), 1);
+        assertEquals(tEvent.getError_code_name(), "SYNTAX_ERROR");
+        assertEquals(tEvent.getFailure_message(), failureMessage);
+    }
+
+    private MaterializedResult runQueryAndWaitForEvents(Session session, String sql, int numMessagesExpected)
+            throws Exception
+    {
+        scriber.initialize(numMessagesExpected);
+        MaterializedResult result = queryRunner.execute(session, sql);
+        scriber.waitForEvents(10);
+
+        return result;
+    }
+
+    private class TestingTwitterScriber
+            extends TwitterScriber
+    {
+        private final List<String> messages;
+        private CountDownLatch messagesLatch;
+
+        public TestingTwitterScriber()
+        {
+            super("test");
+            this.messages = new ArrayList<>();
+        }
+
+        public synchronized void initialize(int numEvents)
+        {
+            messagesLatch = new CountDownLatch(numEvents);
+            messages.clear();
+        }
+
+        public void waitForEvents(int timeoutSeconds)
+                throws InterruptedException
+        {
+            messagesLatch.await(timeoutSeconds, TimeUnit.SECONDS);
+        }
+
+        public List<String> getMessages()
+        {
+            return ImmutableList.copyOf(messages);
+        }
+
+        @Override
+        protected void scribe(String message)
+        {
+            messages.add(message);
+            messagesLatch.countDown();
+        }
+    }
+}


### PR DESCRIPTION
1. Removed `distributedPlanningTime` from QueryStatistics in Version 0.220
https://prestodb.io/docs/current/release/release-0.220.html

2. In JSON struct, `stageInfo.stageStats` replaced with `stageInfo.latestAttemptExecutionInfo.stats` in Version 0.228.

`JsonObject stageStats = stage.getJsonObject("latestAttemptExecutionInfo").getJsonObject("stats");`