### PR TITLE
Port fix to find Parquet column by name

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/parquet/ParquetPageSource.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/parquet/ParquetPageSource.java
@@ -40,7 +40,7 @@ import static com.facebook.presto.hive.HiveColumnHandle.ColumnType.REGULAR;
 import static com.facebook.presto.hive.HiveErrorCode.HIVE_BAD_DATA;
 import static com.facebook.presto.hive.HiveErrorCode.HIVE_CURSOR_ERROR;
 import static com.facebook.presto.hive.parquet.ParquetPageSourceFactory.getParquetType;
-import static com.facebook.presto.parquet.ParquetTypeUtils.getFieldIndex;
+import static com.facebook.presto.hive.parquet.ParquetTypeUtils.findFieldIndexByName;
 import static com.facebook.presto.parquet.ParquetTypeUtils.lookupColumnByName;
 import static com.google.common.base.Preconditions.checkState;
 import static java.util.Objects.requireNonNull;
@@ -167,7 +167,7 @@ public class ParquetPageSource
                     Optional<Field> field = fields.get(fieldId);
                     int fieldIndex;
                     if (useParquetColumnNames) {
-                        fieldIndex = getFieldIndex(fileSchema, columnNames.get(fieldId));
+                        fieldIndex = findFieldIndexByName(fileSchema, columnNames.get(fieldId));
                     }
                     else {
                         fieldIndex = hiveColumnIndexes[fieldId];

--- a/presto-hive/src/main/java/com/facebook/presto/hive/parquet/ParquetPageSourceFactory.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/parquet/ParquetPageSourceFactory.java
@@ -71,10 +71,10 @@ import static com.facebook.presto.hive.HiveSessionProperties.getParquetMaxReadBl
 import static com.facebook.presto.hive.HiveSessionProperties.isFailOnCorruptedParquetStatistics;
 import static com.facebook.presto.hive.HiveSessionProperties.isUseParquetColumnNames;
 import static com.facebook.presto.hive.parquet.HdfsParquetDataSource.buildHdfsParquetDataSource;
+import static com.facebook.presto.hive.parquet.ParquetTypeUtils.findParquetTypeByName;
 import static com.facebook.presto.memory.context.AggregatedMemoryContext.newSimpleAggregatedMemoryContext;
 import static com.facebook.presto.parquet.ParquetTypeUtils.getColumnIO;
 import static com.facebook.presto.parquet.ParquetTypeUtils.getDescriptors;
-import static com.facebook.presto.parquet.ParquetTypeUtils.getParquetTypeByName;
 import static com.facebook.presto.parquet.ParquetTypeUtils.getSubfieldType;
 import static com.facebook.presto.parquet.predicate.PredicateUtils.buildPredicate;
 import static com.facebook.presto.parquet.predicate.PredicateUtils.predicateMatches;
@@ -277,7 +277,7 @@ public class ParquetPageSourceFactory
     {
         org.apache.parquet.schema.Type type = null;
         if (useParquetColumnNames) {
-            type = getParquetTypeByName(column.getName(), messageType);
+            type = findParquetTypeByName(column.getName(), messageType);
         }
         else if (column.getHiveColumnIndex() < messageType.getFieldCount()) {
             type = messageType.getType(column.getHiveColumnIndex());

--- a/presto-hive/src/main/java/com/facebook/presto/hive/parquet/ParquetTypeUtils.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/parquet/ParquetTypeUtils.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.hive.parquet;
+
+import org.apache.parquet.io.ColumnIO;
+import org.apache.parquet.io.GroupColumnIO;
+import org.apache.parquet.schema.MessageType;
+
+import static com.facebook.presto.parquet.ParquetTypeUtils.getFieldIndex;
+import static com.facebook.presto.parquet.ParquetTypeUtils.getParquetTypeByName;
+import static com.facebook.presto.parquet.ParquetTypeUtils.lookupColumnByName;
+
+public class ParquetTypeUtils
+{
+    private ParquetTypeUtils()
+    {
+    }
+
+    /**
+     * Find the column type by name using returning the first match with the following logic:
+     * <ul>
+     * <li>direct match</li>
+     * <li>case-insensitive match</li>
+     * <li>if the name ends with _, remove it and direct match</li>
+     * <li>if the name ends with _, remove it and case-insensitive match</li>
+     * </ul>
+     */
+    public static org.apache.parquet.schema.Type findParquetTypeByName(String name, MessageType messageType)
+    {
+        org.apache.parquet.schema.Type type = getParquetTypeByName(name, messageType);
+
+        if (type == null && name.endsWith("_")) {
+            type = getParquetTypeByName(name.substring(0, name.length() - 1), messageType);
+        }
+        return type;
+    }
+
+    // Find the column index by name following the same logic as findParquetTypeByName
+    public static int findFieldIndexByName(MessageType fileSchema, String name)
+    {
+        int fieldIndex = getFieldIndex(fileSchema, name);
+
+        if (fieldIndex == -1 && name.endsWith("_")) {
+            fieldIndex = getFieldIndex(fileSchema, name.substring(0, name.length() - 1));
+        }
+
+        return fieldIndex;
+    }
+
+    // Find the ColumnIO by name following the same logic as findParquetTypeByName
+    public static ColumnIO findColumnIObyName(GroupColumnIO groupColumnIO, String name)
+    {
+        ColumnIO columnIO = lookupColumnByName(groupColumnIO, name);
+
+        if (columnIO == null && name.endsWith("_")) {
+            columnIO = lookupColumnByName(groupColumnIO, name.substring(0, name.length() - 1));
+        }
+
+        return columnIO;
+    }
+}

--- a/presto-hive/src/main/java/org/apache/parquet/io/ColumnIOConverter.java
+++ b/presto-hive/src/main/java/org/apache/parquet/io/ColumnIOConverter.java
@@ -27,9 +27,9 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Optional;
 
+import static com.facebook.presto.hive.parquet.ParquetTypeUtils.findColumnIObyName;
 import static com.facebook.presto.parquet.ParquetTypeUtils.getArrayElementColumn;
 import static com.facebook.presto.parquet.ParquetTypeUtils.getMapKeyValueColumn;
-import static com.facebook.presto.parquet.ParquetTypeUtils.lookupColumnByName;
 import static com.facebook.presto.spi.type.StandardTypes.ARRAY;
 import static com.facebook.presto.spi.type.StandardTypes.MAP;
 import static com.facebook.presto.spi.type.StandardTypes.ROW;
@@ -61,7 +61,7 @@ public class ColumnIOConverter
             for (int i = 0; i < fields.size(); i++) {
                 NamedTypeSignature namedTypeSignature = fields.get(i).getNamedTypeSignature();
                 String name = namedTypeSignature.getName().get().toLowerCase(Locale.ENGLISH);
-                Optional<Field> field = constructField(parameters.get(i), lookupColumnByName(groupColumnIO, name));
+                Optional<Field> field = constructField(parameters.get(i), findColumnIObyName(groupColumnIO, name));
                 structHasParameters |= field.isPresent();
                 fieldsBuilder.add(field);
             }


### PR DESCRIPTION
Find the column type by name using returning the first match with the following logic:

- direct match
- case-insensitive match
- if the name ends with _, remove it and direct match
- if the name ends with _, remove it and case-insensitive match