### PR TITLE
Fix presto build failures for java 9&11

### DIFF
--- a/presto-cache/pom.xml
+++ b/presto-cache/pom.xml
@@ -52,6 +52,11 @@
         </dependency>
 
         <dependency>
+            <groupId>javax.annotation</groupId>
+            <artifactId>javax.annotation-api</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>com.google.code.findbugs</groupId>
             <artifactId>jsr305</artifactId>
             <optional>true</optional>


### PR DESCRIPTION

[ERROR] COMPILATION ERROR :
[INFO] -------------------------------------------------------------
[ERROR] /Users/beinanw/w/presto/presto-main/src/main/java/com/facebook/presto/transaction/InMemoryTransactionManager.java:[587,46] incompatible types: inference variable T has incompatible bounds
    lower bounds: com.google.common.util.concurrent.ListenableFuture<? extends capture#1 of ? extends java.lang.Object>,java.lang.Object
    lower bounds: com.google.common.util.concurrent.ListenableFuture<? extends java.lang.Object>


I think it’s caused by an unspecified behavior (or a bug) in some newer version of JDK 9 & 11

https://bugs.openjdk.java.net/browse/JDK-8206142

https://bugs.openjdk.java.net/browse/JDK-8016196

So I add the type parameter explicitly to prevent javac to reduce the type.
