### PR TITLE
Compare type by (name,type) pair rather than (index,type) pair during Parquet schema mismatch checking

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/parquet/ParquetPageSourceFactory.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/parquet/ParquetPageSourceFactory.java
@@ -32,6 +32,7 @@ import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.Subfield;
 import com.facebook.presto.spi.predicate.Domain;
 import com.facebook.presto.spi.predicate.TupleDomain;
+import com.facebook.presto.spi.type.RowType;
 import com.facebook.presto.spi.type.StandardTypes;
 import com.facebook.presto.spi.type.Type;
 import com.facebook.presto.spi.type.TypeManager;
@@ -62,6 +63,7 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import static com.facebook.presto.hive.HiveColumnHandle.ColumnType.REGULAR;
 import static com.facebook.presto.hive.HiveErrorCode.HIVE_BAD_DATA;
@@ -94,6 +96,7 @@ import static com.facebook.presto.spi.type.StandardTypes.TINYINT;
 import static com.facebook.presto.spi.type.StandardTypes.VARBINARY;
 import static com.facebook.presto.spi.type.StandardTypes.VARCHAR;
 import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.base.Strings.nullToEmpty;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
@@ -322,8 +325,19 @@ public class ParquetPageSourceFactory
             switch (prestoType) {
                 case ROW:
                     if (groupType.getFields().size() == type.getTypeParameters().size()) {
+                        checkState(type instanceof RowType, "It must be a RowType here.");
+                        RowType rowType = (RowType) type;
+                        Map<String, Type> prestoFieldMap = rowType.getFields().stream().collect(
+                                Collectors.toMap(
+                                        f -> f.getName().get(),
+                                        f -> f.getType()));
                         for (int i = 0; i < groupType.getFields().size(); i++) {
-                            if (!checkSchemaMatch(groupType.getFields().get(i), type.getTypeParameters().get(i))) {
+                            org.apache.parquet.schema.Type parquetFieldType = groupType.getFields().get(i);
+                            Type prestoFieldType = prestoFieldMap.get(parquetFieldType.getName());
+                            if (prestoFieldType == null) {
+                                prestoFieldType = prestoFieldMap.get(parquetFieldType.getName() + "_");
+                            }
+                            if (!checkSchemaMatch(parquetFieldType, prestoFieldType)) {
                                 return false;
                             }
                         }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/parquet/ParquetPageSourceFactory.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/parquet/ParquetPageSourceFactory.java
@@ -59,6 +59,7 @@ import javax.inject.Inject;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Optional;
@@ -329,15 +330,16 @@ public class ParquetPageSourceFactory
                         RowType rowType = (RowType) type;
                         Map<String, Type> prestoFieldMap = rowType.getFields().stream().collect(
                                 Collectors.toMap(
-                                        f -> f.getName().get(),
+                                        f -> f.getName().get().toLowerCase(Locale.ENGLISH),
                                         f -> f.getType()));
                         for (int i = 0; i < groupType.getFields().size(); i++) {
                             org.apache.parquet.schema.Type parquetFieldType = groupType.getFields().get(i);
-                            Type prestoFieldType = prestoFieldMap.get(parquetFieldType.getName());
+                            String fieldName = parquetFieldType.getName().toLowerCase(Locale.ENGLISH);
+                            Type prestoFieldType = prestoFieldMap.get(fieldName);
                             if (prestoFieldType == null) {
-                                prestoFieldType = prestoFieldMap.get(parquetFieldType.getName() + "_");
+                                prestoFieldType = prestoFieldMap.get(fieldName + "_");
                             }
-                            if (!checkSchemaMatch(parquetFieldType, prestoFieldType)) {
+                            if (prestoFieldType == null || !checkSchemaMatch(parquetFieldType, prestoFieldType)) {
                                 return false;
                             }
                         }


### PR DESCRIPTION
Regarding parquet's schema mismatch checking, the existing implementation is selecting each sub-field by its index,  which might cause fake alert of mismatching.  e.g.
struct<a bigint, b string>. might mismatch parquet's group type {b binary, a int64},  but actually they are the same type.

So we add a map of <name, type> to compare each sub-field by name->type pair rather than index->type pire.