### PR TITLE
Query predictor tpch-based fake dataset

### DIFF
--- a/presto-query-predictor/query_predictor/datasets/__init__.py
+++ b/presto-query-predictor/query_predictor/datasets/__init__.py
@@ -1,0 +1,14 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from .loader import load_tpch
+
+__all__ = ["load_tpch"]

--- a/presto-query-predictor/query_predictor/datasets/data/tpch.csv
+++ b/presto-query-predictor/query_predictor/datasets/data/tpch.csv
@@ -1,0 +1,637 @@
+query_id,user_,source,environment,catalog,query_state,query,peak_memory_bytes,cpu_time_ms
+20000101_161800_00237_qgp7p,alice,service-ad-hoc,presto_a,prod_a,FINISHED,"select
+    l_returnflag,
+    l_linestatus,
+    sum(l_quantity) as sum_qty,
+    sum(l_extendedprice) as sum_base_price,
+    sum(l_extendedprice * (1 - l_discount)) as sum_disc_price,
+    sum(l_extendedprice * (1 - l_discount) * (1 + l_tax)) as sum_charge,
+    avg(l_quantity) as avg_qty,
+    avg(l_extendedprice) as avg_price,
+    avg(l_discount) as avg_disc,
+    count(*) as count_order
+from
+    lineitem
+where
+    l_shipdate <= date '1998-12-01' - interval ':1' day
+group by
+    l_returnflag,
+    l_linestatus
+order by
+    l_returnflag,
+    l_linestatus
+LIMIT 1;",593377697,3433802
+20000517_022404_00036_qgp7p,bob,presto-jdbc,presto_a,prod_a,FINISHED,"select
+    sum(l_extendedprice * l_discount) as revenue
+from
+    lineitem
+where
+    l_shipdate >= date ':1'
+    and l_shipdate < date ':1' + interval '1' year
+    and l_discount between :2 - 0.01 and :2 + 0.01
+    and l_quantity < :3
+LIMIT 1;",29440,48
+20000518_075555_00145_qgp7p,alice,presto-jdbc,presto_a,prod_a,FINISHED,"select
+    s_acctbal,
+    s_name,
+    n_name,
+    p_partkey,
+    p_mfgr,
+    s_address,
+    s_phone,
+    s_comment
+from
+    part,
+    supplier,
+    partsupp,
+    nation,
+    region
+where
+    p_partkey = ps_partkey
+    and s_suppkey = ps_suppkey
+    and p_size = :1
+    and p_type like '%:2'
+    and s_nationkey = n_nationkey
+    and n_regionkey = r_regionkey
+    and r_name = ':3'
+    and ps_supplycost = (
+        select
+            min(ps_supplycost)
+        from
+            partsupp,
+            supplier,
+            nation,
+            region
+        where
+            p_partkey = ps_partkey
+            and s_suppkey = ps_suppkey
+            and s_nationkey = n_nationkey
+            and n_regionkey = r_regionkey
+            and r_name = ':3'
+    )
+order by
+    s_acctbal desc,
+    n_name,
+    s_name,
+    p_partkey
+LIMIT 100;",438872682471,350364385
+20000518_065922_00109_qgp7p,charley,service-ad-hoc,presto_a,prod_a,FINISHED,"select
+    l_orderkey,
+    sum(l_extendedprice * (1 - l_discount)) as revenue,
+    o_orderdate,
+    o_shippriority
+from
+    customer,
+    orders,
+    lineitem
+where
+    c_mktsegment = ':1'
+    and c_custkey = o_custkey
+    and l_orderkey = o_orderkey
+    and o_orderdate < date ':2'
+    and l_shipdate > date ':2'
+group by
+    l_orderkey,
+    o_orderdate,
+    o_shippriority
+order by
+    revenue desc,
+    o_orderdate
+LIMIT 10;",1680,56762
+20000101_160650_00236_qgp7p,sophia,service-ad-hoc,presto_a,prod_a,FINISHED,"select
+    o_orderpriority,
+    count(*) as order_count
+from
+    orders
+where
+    o_orderdate >= date ':1'
+    and o_orderdate < date ':1' + interval '3' month
+    and exists (
+        select
+            *
+        from
+            lineitem
+        where
+            l_orderkey = o_orderkey
+            and l_commitdate < l_receiptdate
+    )
+group by
+    o_orderpriority
+order by
+    o_orderpriority
+LIMIT 1;",159130326975,12849104
+20000101_160409_00235_qgp7p,bob,presto-jdbc,presto_a,prod_b,FINISHED,"select
+    n_name,
+    sum(l_extendedprice * (1 - l_discount)) as revenue
+from
+    customer,
+    orders,
+    lineitem,
+    supplier,
+    nation,
+    region
+where
+    c_custkey = o_custkey
+    and l_orderkey = o_orderkey
+    and l_suppkey = s_suppkey
+    and c_nationkey = s_nationkey
+    and s_nationkey = n_nationkey
+    and n_regionkey = r_regionkey
+    and r_name = ':1'
+    and o_orderdate >= date ':2'
+    and o_orderdate < date ':2' + interval '1' year
+group by
+    n_name
+order by
+    revenue desc
+LIMIT 1;",3401,6201
+20000101_165618_00458_ccrk7,charley,presto-jdbc,presto_b,prod_a,FINISHED,"select
+    supp_nation,
+    cust_nation,
+    l_year,
+    sum(volume) as revenue
+from
+    (
+        select
+            n1.n_name as supp_nation,
+            n2.n_name as cust_nation,
+            extract(year from l_shipdate) as l_year,
+            l_extendedprice * (1 - l_discount) as volume
+        from
+            supplier,
+            lineitem,
+            orders,
+            customer,
+            nation n1,
+            nation n2
+        where
+            s_suppkey = l_suppkey
+            and o_orderkey = l_orderkey
+            and c_custkey = o_custkey
+            and s_nationkey = n1.n_nationkey
+            and c_nationkey = n2.n_nationkey
+            and (
+                (n1.n_name = ':1' and n2.n_name = ':2')
+                or (n1.n_name = ':2' and n2.n_name = ':1')
+            )
+            and l_shipdate between date '1995-01-01' and date '1996-12-31'
+    ) as shipping
+group by
+    supp_nation,
+    cust_nation,
+    l_year
+order by
+    supp_nation,
+    cust_nation,
+    l_year
+LIMIT 1;",2957703163,5387868
+20000101_165429_00457_ccrk7,charley,presto-jdbc,presto_b,prod_b,FINISHED,"select
+    o_year,
+    sum(case
+        when nation = ':1' then volume
+        else 0
+    end) / sum(volume) as mkt_share
+from
+    (
+        select
+            extract(year from o_orderdate) as o_year,
+            l_extendedprice * (1 - l_discount) as volume,
+            n2.n_name as nation
+        from
+            part,
+            supplier,
+            lineitem,
+            orders,
+            customer,
+            nation n1,
+            nation n2,
+            region
+        where
+            p_partkey = l_partkey
+            and s_suppkey = l_suppkey
+            and l_orderkey = o_orderkey
+            and o_custkey = c_custkey
+            and c_nationkey = n1.n_nationkey
+            and n1.n_regionkey = r_regionkey
+            and r_name = ':2'
+            and s_nationkey = n2.n_nationkey
+            and o_orderdate between date '1995-01-01' and date '1996-12-31'
+            and p_type = ':3'
+    ) as all_nations
+group by
+    o_year
+order by
+    o_year
+LIMIT 1;",5221597167,8031578
+20000101_165204_00456_ccrk7,alice,presto-jdbc,presto_b,prod_a,FINISHED,"select
+    nation,
+    o_year,
+    sum(amount) as sum_profit
+from
+    (
+        select
+            n_name as nation,
+            extract(year from o_orderdate) as o_year,
+            l_extendedprice * (1 - l_discount) - ps_supplycost * l_quantity as amount
+        from
+            part,
+            supplier,
+            lineitem,
+            partsupp,
+            orders,
+            nation
+        where
+            s_suppkey = l_suppkey
+            and ps_suppkey = l_suppkey
+            and ps_partkey = l_partkey
+            and p_partkey = l_partkey
+            and o_orderkey = l_orderkey
+            and s_nationkey = n_nationkey
+            and p_name like '%:1%'
+    ) as profit
+group by
+    nation,
+    o_year
+order by
+    nation,
+    o_year desc
+LIMIT 1;",140915333,2688071
+20000101_165133_00455_ccrk7,emma,presto-jdbc,presto_b,prod_a,FINISHED,"select
+    c_custkey,
+    c_name,
+    sum(l_extendedprice * (1 - l_discount)) as revenue,
+    c_acctbal,
+    n_name,
+    c_address,
+    c_phone,
+    c_comment
+from
+    customer,
+    orders,
+    lineitem,
+    nation
+where
+    c_custkey = o_custkey
+    and l_orderkey = o_orderkey
+    and o_orderdate >= date ':1'
+    and o_orderdate < date ':1' + interval '3' month
+    and l_returnflag = 'R'
+    and c_nationkey = n_nationkey
+group by
+    c_custkey,
+    c_name,
+    c_acctbal,
+    c_phone,
+    n_name,
+    c_address,
+    c_comment
+order by
+    revenue desc
+LIMIT 20;",242967739,3702539
+20000101_164243_00454_ccrk7,alice,presto-jdbc,presto_b,prod_a,FINISHED,"select
+    ps_partkey,
+    sum(ps_supplycost * ps_availqty) as value
+from
+    partsupp,
+    supplier,
+    nation
+where
+    ps_suppkey = s_suppkey
+    and s_nationkey = n_nationkey
+    and n_name = ':1'
+group by
+    ps_partkey having
+        sum(ps_supplycost * ps_availqty) > (
+            select
+                sum(ps_supplycost * ps_availqty) * :2
+            from
+                partsupp,
+                supplier,
+                nation
+            where
+                ps_suppkey = s_suppkey
+                and s_nationkey = n_nationkey
+                and n_name = ':1'
+        )
+order by
+    value desc
+LIMIT 1;",35973016266,12514289
+20000101_164201_00453_ccrk7,bob,presto-jdbc,presto_b,prod_b,FINISHED,"select
+	l_shipmode,
+	sum(case
+		when o_orderpriority = '1-URGENT'
+			or o_orderpriority = '2-HIGH'
+			then 1
+		else 0
+	end) as high_line_count,
+	sum(case
+		when o_orderpriority <> '1-URGENT'
+			and o_orderpriority <> '2-HIGH'
+			then 1
+		else 0
+	end) as low_line_count
+from
+	orders,
+	lineitem
+where
+	o_orderkey = l_orderkey
+	and l_shipmode in (':1', ':2')
+	and l_commitdate < l_receiptdate
+	and l_shipdate < l_commitdate
+	and l_receiptdate >= date ':3'
+	and l_receiptdate < date ':3' + interval '1' year
+group by
+	l_shipmode
+order by
+	l_shipmode
+LIMIT 1;",624312149553,770804210
+20000101_163939_00452_ccrk7,bob,presto-jdbc,presto_b,prod_a,FINISHED,"select
+	c_count,
+	count(*) as custdist
+from
+	(
+		select
+			c_custkey,
+			count(o_orderkey)
+		from
+			customer left outer join orders on
+				c_custkey = o_custkey
+				and o_comment not like '%:1%:2%'
+		group by
+			c_custkey
+	) as c_orders (c_custkey, c_count)
+group by
+	c_count
+order by
+	custdist desc,
+	c_count desc
+LIMIT 1;",2375115927,5146132
+20000101_163836_00451_ccrk7,emma,presto-jdbc,presto_b,prod_a,FINISHED,"select
+	100.00 * sum(case
+		when p_type like 'PROMO%'
+			then l_extendedprice * (1 - l_discount)
+		else 0
+	end) / sum(l_extendedprice * (1 - l_discount)) as promo_revenue
+from
+	lineitem,
+	part
+where
+	l_partkey = p_partkey
+	and l_shipdate >= date ':1'
+	and l_shipdate < date ':1' + interval '1' month
+LIMIT 1;",3321697973,4905242
+20000101_165901_00462_ccrk7,bob,presto-jdbc,presto_b,prod_a,FINISHED,"select
+	s_suppkey,
+	s_name,
+	s_address,
+	s_phone,
+	total_revenue
+from
+	supplier,
+	revenue:s
+where
+	s_suppkey = supplier_no
+	and total_revenue = (
+		select
+			max(total_revenue)
+		from
+			revenue:s
+	)
+order by
+	s_suppkey
+LIMIT 1;",2445581367,4900687
+20000101_165837_00461_ccrk7,sophia,presto-jdbc,presto_b,prod_a,FINISHED,"select
+	p_brand,
+	p_type,
+	p_size,
+	count(distinct ps_suppkey) as supplier_cnt
+from
+	partsupp,
+	part
+where
+	p_partkey = ps_partkey
+	and p_brand <> ':1'
+	and p_type not like ':2%'
+	and p_size in (:3, :4, :5, :6, :7, :8, :9, :10)
+	and ps_suppkey not in (
+		select
+			s_suppkey
+		from
+			supplier
+		where
+			s_comment like '%Customer%Complaints%'
+	)
+group by
+	p_brand,
+	p_type,
+	p_size
+order by
+	supplier_cnt desc,
+	p_brand,
+	p_type,
+	p_size
+LIMIT 1;",1105805651,1635377
+20000101_165732_00460_ccrk7,charley,presto-jdbc,presto_b,prod_a,FINISHED,"select
+	sum(l_extendedprice) / 7.0 as avg_yearly
+from
+	lineitem,
+	part,
+	(SELECT l_partkey AS agg_partkey, 0.2 * avg(l_quantity) AS avg_quantity FROM lineitem GROUP BY l_partkey) part_agg
+where
+	p_partkey = l_partkey
+	and agg_partkey = l_partkey
+	and p_brand = ':1'
+	and p_container = ':2'
+	and l_quantity < avg_quantity
+LIMIT 1;",229796073,3349202
+20000101_165658_00459_ccrk7,alice,presto-jdbc,presto_b,prod_a,FINISHED,"select
+	c_name,
+	c_custkey,
+	o_orderkey,
+	o_orderdate,
+	o_totalprice,
+	sum(l_quantity)
+from
+	customer,
+	orders,
+	lineitem
+where
+	o_orderkey in (
+		select
+			l_orderkey
+		from
+			lineitem
+		group by
+			l_orderkey having
+				sum(l_quantity) > :1
+	)
+	and c_custkey = o_custkey
+	and o_orderkey = l_orderkey
+group by
+	c_name,
+	c_custkey,
+	o_orderkey,
+	o_orderdate,
+	o_totalprice
+order by
+	o_totalprice desc,
+	o_orderdate
+LIMIT 100;",686803159,6275402
+20000101_163645_00450_ccrk7,sophia,presto-jdbc,presto_b,prod_a,FINISHED,"select
+	sum(l_extendedprice* (1 - l_discount)) as revenue
+from
+	lineitem,
+	part
+where
+	(
+		p_partkey = l_partkey
+		and p_brand = ':1'
+		and p_container in ('SM CASE', 'SM BOX', 'SM PACK', 'SM PKG')
+		and l_quantity >= :4 and l_quantity <= :4 + 10
+		and p_size between 1 and 5
+		and l_shipmode in ('AIR', 'AIR REG')
+		and l_shipinstruct = 'DELIVER IN PERSON'
+	)
+	or
+	(
+		p_partkey = l_partkey
+		and p_brand = ':2'
+		and p_container in ('MED BAG', 'MED BOX', 'MED PKG', 'MED PACK')
+		and l_quantity >= :5 and l_quantity <= :5 + 10
+		and p_size between 1 and 10
+		and l_shipmode in ('AIR', 'AIR REG')
+		and l_shipinstruct = 'DELIVER IN PERSON'
+	)
+	or
+	(
+		p_partkey = l_partkey
+		and p_brand = ':3'
+		and p_container in ('LG CASE', 'LG BOX', 'LG PACK', 'LG PKG')
+		and l_quantity >= :6 and l_quantity <= :6 + 10
+		and p_size between 1 and 15
+		and l_shipmode in ('AIR', 'AIR REG')
+		and l_shipinstruct = 'DELIVER IN PERSON'
+	)
+LIMIT 1;",112,108
+20000101_163611_00449_ccrk7,emma,service-ad-hoc,presto_b,prod_a,FINISHED,"select
+	s_name,
+	s_address
+from
+	supplier,
+	nation
+where
+	s_suppkey in (
+		select
+			ps_suppkey
+		from
+			partsupp,
+			(
+				select
+					l_partkey agg_partkey,
+					l_suppkey agg_suppkey,
+					0.5 * sum(l_quantity) AS agg_quantity
+				from
+					lineitem
+				where
+					l_shipdate >= date ':2'
+					and l_shipdate < date ':2' + interval '1' year
+				group by
+					l_partkey,
+					l_suppkey
+			) agg_lineitem
+		where
+			agg_partkey = ps_partkey
+			and agg_suppkey = ps_suppkey
+			and ps_partkey in (
+				select
+					p_partkey
+				from
+					part
+				where
+					p_name like ':1%'
+			)
+			and ps_availqty > agg_quantity
+	)
+	and s_nationkey = n_nationkey
+	and n_name = ':3'
+order by
+	s_name
+LIMIT 1;",848,124
+20000101_163530_00448_ccrk7,john,presto-jdbc,presto_b,prod_a,FINISHED,"select
+	s_name,
+	count(*) as numwait
+from
+	supplier,
+	lineitem l1,
+	orders,
+	nation
+where
+	s_suppkey = l1.l_suppkey
+	and o_orderkey = l1.l_orderkey
+	and o_orderstatus = 'F'
+	and l1.l_receiptdate > l1.l_commitdate
+	and exists (
+		select
+			*
+		from
+			lineitem l2
+		where
+			l2.l_orderkey = l1.l_orderkey
+			and l2.l_suppkey <> l1.l_suppkey
+	)
+	and not exists (
+		select
+			*
+		from
+			lineitem l3
+		where
+			l3.l_orderkey = l1.l_orderkey
+			and l3.l_suppkey <> l1.l_suppkey
+			and l3.l_receiptdate > l3.l_commitdate
+	)
+	and s_nationkey = n_nationkey
+	and n_name = ':1'
+group by
+	s_name
+order by
+	numwait desc,
+	s_name
+LIMIT 100;",3401307394,6201899
+20000101_163437_00447_ccrk7,john,service-ad-hoc,presto_b,prod_a,FINISHED,"select
+	cntrycode,
+	count(*) as numcust,
+	sum(c_acctbal) as totacctbal
+from
+	(
+		select
+			substring(c_phone from 1 for 2) as cntrycode,
+			c_acctbal
+		from
+			customer
+		where
+			substring(c_phone from 1 for 2) in
+				(':1', ':2', ':3', ':4', ':5', ':6', ':7')
+			and c_acctbal > (
+				select
+					avg(c_acctbal)
+				from
+					customer
+				where
+					c_acctbal > 0.00
+					and substring(c_phone from 1 for 2) in
+						(':1', ':2', ':3', ':4', ':5', ':6', ':7')
+			)
+			and not exists (
+				select
+					*
+				from
+					orders
+				where
+					o_custkey = c_custkey
+			)
+	) as custsale
+group by
+	cntrycode
+order by
+	cntrycode
+LIMIT 1;",763,116

--- a/presto-query-predictor/query_predictor/datasets/loader.py
+++ b/presto-query-predictor/query_predictor/datasets/loader.py
@@ -1,0 +1,51 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+This module contains the methods to load datasets.
+"""
+from pathlib import Path
+
+import pandas as pd
+
+
+def load_tpch() -> pd.DataFrame:
+    """
+    Loads and returns a TPC-H based fake dataset for classification.
+
+    This dataset is created with TPC-H SQL queries and corresponding fake attributes.
+    The values are not obtained from real production environment.
+
+    The dataset has 22 samples. It contains the columns: query_id, user_, source,
+    environment, catalog, query_state, query, peak_memory_bytes, and cpu_time_ms.
+
+    :return: A pandas data frame with the tpch dataset.
+
+    To use:
+    >>> from query_predictor.datasets import load_tpch
+    >>> data = load_tpch()
+    >>> print(data.columns)
+    """
+    curr_dir = Path(__file__).parent
+    tpch_path = curr_dir / "data/tpch.csv"
+
+    return _load_pandas_csv(tpch_path)
+
+
+def _load_pandas_csv(file_path: str, delimiter: str = ",") -> pd.DataFrame:
+    """
+    Loads and returns a pandas dataset.
+
+    :param file_path: The path of the dataset.
+    :param delimiter: The delimiter of the dataset. Comma by default.
+    :return: A pandas data frame.
+    """
+    return pd.read_csv(file_path, delimiter=delimiter)


### PR DESCRIPTION
This PR creates a tpch-based fake dataset for classification.

The dataset is created with TPC-H SQL queries and corresponding fake attributes. The values are not obtained from a real production environment.

The dataset has 22 samples. It contains the columns: query_id, user_, source, environment, catalog, query_state, query, peak_memory_bytes, and cpu_time_ms.
